### PR TITLE
[codex] Flutter 실험 코드 제외 설정 추가

### DIFF
--- a/.cursor/rules/architecture-guide.mdc
+++ b/.cursor/rules/architecture-guide.mdc
@@ -1,0 +1,5 @@
+---
+description:
+globs:
+alwaysApply: false
+---

--- a/.cursor/rules/development-workflow.mdc
+++ b/.cursor/rules/development-workflow.mdc
@@ -1,0 +1,5 @@
+---
+description:
+globs:
+alwaysApply: false
+---

--- a/.cursor/rules/flutter-conversion-plan.mdc
+++ b/.cursor/rules/flutter-conversion-plan.mdc
@@ -1,0 +1,5 @@
+---
+description:
+globs:
+alwaysApply: false
+---

--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ Derived/
 
 ### Tuist managed dependencies ###
 Tuist/.build
+
+### Local conversion experiments ###
+flutter_memorybox/

--- a/docs/superpowers/plans/2026-04-27-android-memorybox-parity.md
+++ b/docs/superpowers/plans/2026-04-27-android-memorybox-parity.md
@@ -1,0 +1,103 @@
+# Android MemoryBox Parity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [x]`) syntax for tracking.
+
+**Goal:** Move `android_memorybox/` from buildable MVP foundation toward real Android behavior parity with the iOS MemoryBox app.
+
+**Architecture:** Keep the single Android `:app` module, but make feature packages behave like the iOS modules: repository boundary, local-first storage, API path/body parity, and Compose screens wired to real state. Use Kotlin serialization and app-private JSON/SharedPreferences stores first to avoid migration overhead while preserving model/API contracts for later Room/Retrofit replacement.
+
+**Tech Stack:** Kotlin, Jetpack Compose, Android app-private files, SharedPreferences, `HttpURLConnection`, Kotlin serialization, JUnit.
+
+---
+
+## Requirements Summary
+
+- Persist calendar, map trips, D-Day widgets, session, and friend state across app restarts.
+- Mirror iOS API paths and request/response bodies for auth, calendar sync, and friend features.
+- Implement local-first calendar behavior: fetch local data, optionally sync with server when logged in, queue offline deletes, sync on login.
+- Implement trip add/edit with image copy-to-private-storage semantics.
+- Implement D-Day widget records with image/title/date display options and native widget refresh.
+- Keep existing iOS files untouched.
+
+## Assumptions
+
+- `BASE_URL` and social login keys are not available in the repo, so Android uses a configurable base URL field and real HTTP client boundary without hardcoding secrets.
+- Apple login on Android requires external OAuth/platform setup; this pass implements the backend-compatible login call and a manual token entry/development login shell.
+- Room/Retrofit can replace JSON stores/`HttpURLConnection` later without changing domain models.
+
+## Out Of Scope
+
+- Play Store signing/release setup.
+- Pixel-perfect UI polish.
+- Production Kakao/Apple SDK setup requiring app keys, redirect URLs, and console configuration.
+- Backend contract changes.
+
+## Tasks
+
+### Task 1: Core Network And Auth
+
+**Files:**
+- Modify/Create under `android_memorybox/app/src/main/java/com/memorybox/android/core/network/`
+- Modify/Create under `android_memorybox/app/src/main/java/com/memorybox/android/auth/`
+- Test under `android_memorybox/app/src/test/java/com/memorybox/android/auth/`
+
+- [x] Add tests for login/refresh request encoding and bearer retry decision.
+- [x] Implement configurable `MemoryBoxConfig`.
+- [x] Implement lightweight JSON HTTP client boundary.
+- [x] Implement `AuthRepository` with `/login`, `/refresh`, `/deleteUser`, session persistence, logout.
+
+### Task 2: Calendar Local-First Repository
+
+**Files:**
+- Modify/Create under `android_memorybox/app/src/main/java/com/memorybox/android/calendar/`
+- Test under `android_memorybox/app/src/test/java/com/memorybox/android/calendar/`
+
+- [x] Add tests for local create/update/delete grouping and sync payload shape.
+- [x] Implement persistent calendar store.
+- [x] Implement repository methods equivalent to iOS `fetch`, `updateTodo`, `updateDiary`, `updateSchedule`, delete methods, and `syncServer`.
+- [x] Wire `CalendarScreen` to repository-backed state.
+
+### Task 3: Map Trip Persistence And Image Flow
+
+**Files:**
+- Modify/Create under `android_memorybox/app/src/main/java/com/memorybox/android/map/`
+- Test under `android_memorybox/app/src/test/java/com/memorybox/android/map/`
+
+- [x] Add tests for trip persistence and image filename storage.
+- [x] Implement trip store keyed by `sigunguCode`.
+- [x] Implement app-private image copy/delete helpers.
+- [x] Wire map tap to add/edit trip bottom sheet or dialog.
+
+### Task 4: Friend API And Screen State
+
+**Files:**
+- Modify/Create under `android_memorybox/app/src/main/java/com/memorybox/android/friend/`
+- Test under `android_memorybox/app/src/test/java/com/memorybox/android/friend/`
+
+- [x] Add tests for friend endpoint request paths/actions.
+- [x] Implement friend repository methods: fetch, requests, request, accept, reject/delete.
+- [x] Wire `FriendScreen` to repository-backed loading/error/list state.
+
+### Task 5: D-Day Widget Parity
+
+**Files:**
+- Modify/Create under `android_memorybox/app/src/main/java/com/memorybox/android/widget/`
+- Modify resources under `android_memorybox/app/src/main/res/`
+- Test under `android_memorybox/app/src/test/java/com/memorybox/android/widget/`
+
+- [x] Add tests for D-Day item upsert/remove/select behavior.
+- [x] Implement image path persistence and alignment options.
+- [x] Wire D-Day UI to persisted records and widget refresh.
+- [x] Render selected widget title/date in native widget.
+
+### Task 6: Integration And Verification
+
+**Files:**
+- Modify `android_memorybox/app/src/main/java/com/memorybox/android/ui/MemoryBoxApp.kt`
+- Modify `android_memorybox/README.md`
+
+- [x] Connect login success to calendar sync.
+- [x] Confirm side menu gating matches iOS.
+- [x] Run `./gradlew testDebugUnitTest`.
+- [x] Run `./gradlew assembleDebug`.
+- [x] Review untracked/generated files and residual risks.

--- a/docs/superpowers/plans/2026-04-27-android-memorybox-port.md
+++ b/docs/superpowers/plans/2026-04-27-android-memorybox-port.md
@@ -1,0 +1,80 @@
+# Android MemoryBox Port Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a standalone Kotlin Android port of the iOS MemoryBox app under `android_memorybox/`.
+
+**Architecture:** The Android app uses a single `:app` module with feature packages mirroring the iOS feature boundaries. Pure domain and utility code is testable on the JVM; Android UI uses Jetpack Compose, local persistence starts with app-private JSON/SharedPreferences repositories, and network code mirrors the existing REST API contracts.
+
+**Tech Stack:** Kotlin, Android Gradle Plugin, Jetpack Compose, Kotlin serialization, OkHttp/HttpURLConnection-compatible API boundary, Android AppWidgetProvider, JUnit.
+
+---
+
+### Task 1: Project Foundation
+
+**Files:**
+- Create: `android_memorybox/settings.gradle.kts`
+- Create: `android_memorybox/build.gradle.kts`
+- Create: `android_memorybox/app/build.gradle.kts`
+- Create: `android_memorybox/app/src/main/AndroidManifest.xml`
+- Create: `android_memorybox/app/src/main/java/com/memorybox/android/MainActivity.kt`
+
+- [x] Write JVM tests for pure date/calendar helpers before implementation.
+- [x] Add Gradle and Android app configuration.
+- [x] Add minimal Activity host and app theme.
+- [x] Run `./gradlew testDebugUnitTest`.
+
+### Task 2: Core Domain And Utilities
+
+**Files:**
+- Create: `android_memorybox/app/src/main/java/com/memorybox/android/core/date/MemoryBoxDates.kt`
+- Create: `android_memorybox/app/src/main/java/com/memorybox/android/calendar/domain/CalendarModels.kt`
+- Create: `android_memorybox/app/src/main/java/com/memorybox/android/widget/domain/DdayModels.kt`
+
+- [x] Implement inclusive D-Day calculation matching iOS.
+- [x] Implement calendar grid range and day key format.
+- [x] Keep models serializable and independent from Android APIs.
+
+### Task 3: Calendar MVP
+
+**Files:**
+- Create under `android_memorybox/app/src/main/java/com/memorybox/android/calendar/`
+
+- [x] Implement in-memory/file-backed repository matching iOS calendar models.
+- [x] Implement Compose month grid, selected-day list, and edit dialogs.
+- [x] Preserve server DTO field names for later Retrofit replacement.
+
+### Task 4: Map MVP
+
+**Files:**
+- Create under `android_memorybox/app/src/main/java/com/memorybox/android/map/`
+- Copy asset: `android_memorybox/app/src/main/assets/sigungu.geojson`
+
+- [x] Implement GeoJSON parser for `SIGUNGU_CD`, `SIGUNGU_NM`, and MultiPolygon coordinates.
+- [x] Implement trip model/store and basic Compose map canvas.
+- [x] Defer exact image clipping polish if it risks buildability.
+
+### Task 5: Auth/Friend MVP
+
+**Files:**
+- Create under `android_memorybox/app/src/main/java/com/memorybox/android/auth/`
+- Create under `android_memorybox/app/src/main/java/com/memorybox/android/friend/`
+
+- [x] Implement token/session store and REST endpoint definitions.
+- [x] Implement login dialog shell, logout/delete hooks, friend list/request UI.
+
+### Task 6: D-Day Widget MVP
+
+**Files:**
+- Create under `android_memorybox/app/src/main/java/com/memorybox/android/widget/`
+- Create: `android_memorybox/app/src/main/res/xml/dday_widget_info.xml`
+- Create: `android_memorybox/app/src/main/res/layout/dday_widget.xml`
+
+- [x] Implement D-Day item store and AppWidgetProvider.
+- [x] Render selected item title and inclusive D-Day text in a native Android widget.
+
+### Verification
+
+- [x] Run `./gradlew testDebugUnitTest`.
+- [x] Run `./gradlew assembleDebug`.
+- [x] Report exact pass/fail output and any limitations.


### PR DESCRIPTION
## Summary
- Add `flutter_memorybox/` to `.gitignore` so the Flutter experiment stays out of Git.
- Add the remaining Android port planning docs under `docs/superpowers/plans/`.
- Add existing Cursor rule placeholders under `.cursor/rules/`.

## Validation
- `git diff --cached --check`
- Confirmed `git ls-files --others --exclude-standard` no longer lists `flutter_memorybox/`.