### PR TITLE
Complete MemoryBox priority work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ Tuist/.build
 
 ### Local conversion experiments ###
 flutter_memorybox/
+
+# Local worktrees
+.worktrees/

--- a/Projects/App/Main/Project.swift
+++ b/Projects/App/Main/Project.swift
@@ -11,6 +11,7 @@ let project = Project.configure(
         .Features.Setting.Feature,
         .Features.Login.Feature,
         .Features.Friend.Feature,
+        .Features.Canvas.Feature,
         .Data.Calendar.Data,
         .external(name: "RealmSwift"),
         .external(name: "Realm"),

--- a/Projects/App/Main/Sources/AppView.swift
+++ b/Projects/App/Main/Sources/AppView.swift
@@ -13,6 +13,7 @@ import WidgetFeature
 import LoginFeature
 import FriendFeature
 import SettingFeature
+import CanvasFeature
 
 struct AppView: View {
     
@@ -21,6 +22,7 @@ struct AppView: View {
     @Dependency(\.widgetFeature) var widgetFeature
     @Dependency(\.friendFeature) var friendFeature
     @Dependency(\.settingFeature) var settingFeature
+    @Dependency(\.canvasFeature) var canvasFeature
     
     @Bindable var store: StoreOf<AppReducer>
     
@@ -117,6 +119,8 @@ struct AppView: View {
                         AnyView(friendFeature.makeView())
                     case .setting:
                         AnyView(settingFeature.makeView())
+                    case .canvas:
+                        AnyView(canvasFeature.makeView())
                     }
                 }
             }
@@ -174,6 +178,14 @@ struct sideBarMenu: View {
                 })
                 .foregroundStyle(Color.mbTextBlack)
             }
+
+            Button(action: {
+                store.send(.destinationChanged(.canvas))
+            }, label: {
+                Image(systemName: "pencil.and.scribble")
+                Text("우리 낙서장")
+            })
+            .foregroundStyle(Color.mbTextBlack)
 
             Button(action: {
                 store.send(.destinationChanged(.setting))
@@ -383,12 +395,14 @@ extension AppReducer {
         case widget
         case friend
         case setting
+        case canvas
         
         var id: String {
             switch self {
             case .widget: return "widget"
             case .friend: return "friend"
             case .setting: return "setting"
+            case .canvas: return "canvas"
             }
         }
     }

--- a/Projects/App/Main/Sources/AppView.swift
+++ b/Projects/App/Main/Sources/AppView.swift
@@ -12,6 +12,7 @@ import CalendarFeature
 import WidgetFeature
 import LoginFeature
 import FriendFeature
+import SettingFeature
 
 struct AppView: View {
     
@@ -19,6 +20,7 @@ struct AppView: View {
     @Dependency(\.calendarFeature) var calendarFeature
     @Dependency(\.widgetFeature) var widgetFeature
     @Dependency(\.friendFeature) var friendFeature
+    @Dependency(\.settingFeature) var settingFeature
     
     @Bindable var store: StoreOf<AppReducer>
     
@@ -113,6 +115,8 @@ struct AppView: View {
                         AnyView(widgetFeature.makeView())
                     case .friend:
                         AnyView(friendFeature.makeView())
+                    case .setting:
+                        AnyView(settingFeature.makeView())
                     }
                 }
             }
@@ -170,6 +174,14 @@ struct sideBarMenu: View {
                 })
                 .foregroundStyle(Color.mbTextBlack)
             }
+
+            Button(action: {
+                store.send(.destinationChanged(.setting))
+            }, label: {
+                Image(systemName: "gearshape")
+                Text("설정")
+            })
+            .foregroundStyle(Color.mbTextBlack)
             
             Spacer()
             
@@ -370,11 +382,13 @@ extension AppReducer {
     public enum Destination: Equatable, Identifiable {
         case widget
         case friend
+        case setting
         
         var id: String {
             switch self {
             case .widget: return "widget"
             case .friend: return "friend"
+            case .setting: return "setting"
             }
         }
     }

--- a/Projects/App/Main/coupleapp.WidgetExtension/coupleapp_WidgetExtension.swift
+++ b/Projects/App/Main/coupleapp.WidgetExtension/coupleapp_WidgetExtension.swift
@@ -18,6 +18,7 @@ import WidgetFeature
 struct WidgetEntry: TimelineEntry {
     let date: Date
     let widgetVO: WidgetVO?
+    let canvasSnapshotPath: String?
 }
 
 struct WidgetProvider: AppIntentTimelineProvider {
@@ -25,30 +26,30 @@ struct WidgetProvider: AppIntentTimelineProvider {
     @Dependency(\.widgetRepository) var repository
     
     func placeholder(in context: Context) -> WidgetEntry {
-        WidgetEntry(date: Date(), widgetVO: nil)
+        WidgetEntry(date: Date(), widgetVO: nil, canvasSnapshotPath: LiveCanvasSnapshotReader.latestSnapshotPath())
     }
     
     func snapshot(for configuration: ConfigurationAppIntent, in context: Context) async -> WidgetEntry {
         guard let selectedEntity = configuration.selectedItem else {
-            return WidgetEntry(date: Date(), widgetVO: nil)
+            return WidgetEntry(date: Date(), widgetVO: nil, canvasSnapshotPath: LiveCanvasSnapshotReader.latestSnapshotPath())
         }
         
         let all = repository.fetchWidget()
         let selectedVO = all.first(where: { $0.id == selectedEntity.id })
         
-        return WidgetEntry(date: Date(), widgetVO: selectedVO)
+        return WidgetEntry(date: Date(), widgetVO: selectedVO, canvasSnapshotPath: LiveCanvasSnapshotReader.latestSnapshotPath())
     }
     
     func timeline(for configuration: ConfigurationAppIntent, in context: Context) async -> Timeline<WidgetEntry> {
         
         guard let selected = configuration.selectedItem else {
-            return Timeline(entries: [WidgetEntry(date: .now, widgetVO: nil)], policy: .atEnd)
+            return Timeline(entries: [WidgetEntry(date: .now, widgetVO: nil, canvasSnapshotPath: LiveCanvasSnapshotReader.latestSnapshotPath())], policy: .atEnd)
         }
         
         let all = repository.fetchWidget()
         let vo = all.first(where: { $0.id == selected.id })
         
-        let entry = WidgetEntry(date: .now, widgetVO: vo)
+        let entry = WidgetEntry(date: .now, widgetVO: vo, canvasSnapshotPath: LiveCanvasSnapshotReader.latestSnapshotPath())
         
         let currentDate = Date()
                 let calendar = Calendar.current
@@ -74,7 +75,20 @@ struct coupleapp_WidgetExtensionEntryView : View {
     @Environment(\.widgetFamily) var widgetFamily
     
     var body: some View {
-        if let vo = entry.widgetVO {
+        if let snapshotPath = entry.canvasSnapshotPath, let image = UIImage(contentsOfFile: snapshotPath) {
+            Image(uiImage: image)
+                .resizable()
+                .scaledToFill()
+                .overlay(alignment: .bottomLeading) {
+                    Text("우리 낙서장")
+                        .font(.caption.bold())
+                        .padding(6)
+                        .background(.thinMaterial)
+                        .clipShape(Capsule())
+                        .padding(8)
+                }
+                .containerBackground(.fill, for: .widget)
+        } else if let vo = entry.widgetVO {
             
             switch widgetFamily {
                 
@@ -210,5 +224,17 @@ struct WidgetEntity: AppEntity {
 #Preview(as: .systemSmall) {
     coupleapp_WidgetExtension()
 } timeline: {
-    WidgetEntry(date: .now, widgetVO: WidgetVO(title: "hello"))
+    WidgetEntry(date: .now, widgetVO: WidgetVO(title: "hello"), canvasSnapshotPath: nil)
+}
+
+
+private enum LiveCanvasSnapshotReader {
+    static let appGroupIdentifier = "group.com.bongbong.coupleapp"
+    static let latestFileName = "LiveCanvas/latest_canvas.png"
+
+    static func latestSnapshotPath() -> String? {
+        guard let container = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroupIdentifier) else { return nil }
+        let url = container.appendingPathComponent(latestFileName)
+        return FileManager.default.fileExists(atPath: url.path) ? url.path : nil
+    }
 }

--- a/Projects/CoreKit/Core/Sources/CanvasSnapshotRenderer.swift
+++ b/Projects/CoreKit/Core/Sources/CanvasSnapshotRenderer.swift
@@ -1,0 +1,88 @@
+import Foundation
+import UIKit
+
+public struct CanvasSnapshotStrokeInput: Equatable, Sendable {
+    public let sequence: Int
+    public let toolRawValue: String
+    public let colorHex: String
+    public let lineWidth: Double
+    public let points: [CanvasSnapshotPointInput]
+
+    public init(sequence: Int, toolRawValue: String, colorHex: String, lineWidth: Double, points: [CanvasSnapshotPointInput]) {
+        self.sequence = sequence
+        self.toolRawValue = toolRawValue
+        self.colorHex = colorHex
+        self.lineWidth = lineWidth
+        self.points = points
+    }
+}
+
+public struct CanvasSnapshotPointInput: Equatable, Sendable {
+    public let x: Double
+    public let y: Double
+
+    public init(x: Double, y: Double) {
+        self.x = min(max(x, 0), 1)
+        self.y = min(max(y, 0), 1)
+    }
+}
+
+public enum CanvasSnapshotRenderer {
+    public static func render(
+        strokes: [CanvasSnapshotStrokeInput],
+        size: CGSize = CGSize(width: 800, height: 800),
+        backgroundColor: UIColor = UIColor(red: 0.98, green: 0.93, blue: 0.86, alpha: 1)
+    ) -> UIImage {
+        let renderer = UIGraphicsImageRenderer(size: size)
+        return renderer.image { context in
+            backgroundColor.setFill()
+            context.fill(CGRect(origin: .zero, size: size))
+
+            for stroke in strokes.sorted(by: { $0.sequence < $1.sequence }) {
+                draw(stroke: stroke, in: context.cgContext, size: size, backgroundColor: backgroundColor)
+            }
+        }
+    }
+
+    public static func writePNG(
+        strokes: [CanvasSnapshotStrokeInput],
+        to url: URL,
+        size: CGSize = CGSize(width: 800, height: 800)
+    ) throws -> URL {
+        let image = render(strokes: strokes, size: size)
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try image.pngData()?.write(to: url, options: [.atomic])
+        return url
+    }
+
+    private static func draw(stroke: CanvasSnapshotStrokeInput, in cgContext: CGContext, size: CGSize, backgroundColor: UIColor) {
+        guard stroke.points.count > 1 else { return }
+        cgContext.setLineCap(.round)
+        cgContext.setLineJoin(.round)
+        cgContext.setLineWidth(CGFloat(stroke.lineWidth))
+        cgContext.setStrokeColor(stroke.toolRawValue == "eraser" ? backgroundColor.cgColor : UIColor(hex: stroke.colorHex).cgColor)
+        let first = stroke.points[0]
+        cgContext.beginPath()
+        cgContext.move(to: CGPoint(x: first.x * size.width, y: first.y * size.height))
+        for point in stroke.points.dropFirst() {
+            cgContext.addLine(to: CGPoint(x: point.x * size.width, y: point.y * size.height))
+        }
+        cgContext.strokePath()
+    }
+}
+
+private extension UIColor {
+    convenience init(hex: String) {
+        let cleaned = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+        var int: UInt64 = 0
+        Scanner(string: cleaned).scanHexInt64(&int)
+        let r, g, b: UInt64
+        switch cleaned.count {
+        case 6:
+            (r, g, b) = ((int >> 16) & 0xff, (int >> 8) & 0xff, int & 0xff)
+        default:
+            (r, g, b) = (61, 44, 46)
+        }
+        self.init(red: CGFloat(r) / 255, green: CGFloat(g) / 255, blue: CGFloat(b) / 255, alpha: 1)
+    }
+}

--- a/Projects/CoreKit/Core/Sources/ConfigManager.swift
+++ b/Projects/CoreKit/Core/Sources/ConfigManager.swift
@@ -6,17 +6,43 @@
 //  Copyright © 2025 JIBONG PARK. All rights reserved.
 //
 
+import Foundation
+
 public final class ConfigManager {
     public static let shared = ConfigManager()
-    
+
+    public static let fallbackBaseURL = URL(string: "https://example.invalid")!
+    public static let missingAPIBaseURLMessage = "서버 주소 설정이 없습니다."
+
     private var storage: [String: Any] = [:]
-    
+
     private init() {}
-    
+
+    public var apiBaseURL: URL? {
+        Self.apiBaseURL(from: Bundle.main.object(forInfoDictionaryKey: "BASE_URL"))
+    }
+
+    public var hasValidAPIBaseURL: Bool {
+        apiBaseURL != nil
+    }
+
+    public static func apiBaseURL(from rawValue: Any?) -> URL? {
+        guard let value = rawValue as? String else { return nil }
+
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              let url = URL(string: trimmed),
+              url.scheme != nil,
+              url.host != nil
+        else { return nil }
+
+        return url
+    }
+
     public func set<T>(_ key: String, _ value: T) {
         storage[key] = value
     }
-    
+
     public func get<T>(_ key: String) -> T? {
         storage[key] as? T
     }

--- a/Projects/CoreKit/Core/Sources/ThrottledSnapshotUpdater.swift
+++ b/Projects/CoreKit/Core/Sources/ThrottledSnapshotUpdater.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+public struct ThrottledSnapshotUpdater: Sendable {
+    public let minimumInterval: TimeInterval
+    private var lastUpdateDate: Date?
+
+    public init(minimumInterval: TimeInterval = 2.0, lastUpdateDate: Date? = nil) {
+        self.minimumInterval = minimumInterval
+        self.lastUpdateDate = lastUpdateDate
+    }
+
+    public mutating func shouldUpdate(now: Date = Date()) -> Bool {
+        guard let lastUpdateDate else {
+            self.lastUpdateDate = now
+            return true
+        }
+        guard now.timeIntervalSince(lastUpdateDate) >= minimumInterval else { return false }
+        self.lastUpdateDate = now
+        return true
+    }
+}

--- a/Projects/CoreKit/Core/Sources/ThrottledSnapshotUpdater.swift
+++ b/Projects/CoreKit/Core/Sources/ThrottledSnapshotUpdater.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct ThrottledSnapshotUpdater: Sendable {
+public struct ThrottledSnapshotUpdater: Equatable, Sendable {
     public let minimumInterval: TimeInterval
     private var lastUpdateDate: Date?
 

--- a/Projects/CoreKit/Core/Tests/Sources/ConfigManagerTests.swift
+++ b/Projects/CoreKit/Core/Tests/Sources/ConfigManagerTests.swift
@@ -1,0 +1,22 @@
+import Foundation
+import Testing
+@testable import Core
+
+struct ConfigManagerTests {
+    @Test
+    func apiBaseURLRejectsMissingOrInvalidValues() {
+        #expect(ConfigManager.apiBaseURL(from: nil) == nil)
+        #expect(ConfigManager.apiBaseURL(from: "") == nil)
+        #expect(ConfigManager.apiBaseURL(from: "   ") == nil)
+        #expect(ConfigManager.apiBaseURL(from: "not a url") == nil)
+        #expect(ConfigManager.apiBaseURL(from: 123) == nil)
+    }
+
+    @Test
+    func apiBaseURLAcceptsHTTPURLsWithHost() throws {
+        let url = try #require(ConfigManager.apiBaseURL(from: "https://api.example.com"))
+
+        #expect(url.scheme == "https")
+        #expect(url.host == "api.example.com")
+    }
+}

--- a/Projects/Data/AuthData/Project.swift
+++ b/Projects/Data/AuthData/Project.swift
@@ -7,6 +7,8 @@ let project = Project.configure(
     dependencies: [
         .Domains.Auth.Domain,
         .Core.core,
+        .Data.Common.Data,
+        .external(name: "ComposableArchitecture"),
         .external(name: "Moya")
     ]
 )

--- a/Projects/Data/AuthData/Sources/AuthRepository.swift
+++ b/Projects/Data/AuthData/Sources/AuthRepository.swift
@@ -53,6 +53,10 @@ public final class AuthRepositoryImpl: AuthRepository, @unchecked Sendable {
     public func loginUser(_ user: LoginVO) -> Effect<DataResult<String>> {
         
         return Effect.run { [self] send async in
+            guard ConfigManager.shared.hasValidAPIBaseURL else {
+                await send(DataResult(message: ConfigManager.missingAPIBaseURLMessage))
+                return
+            }
             
             let result = await provider.request(.login(type: user.type, jwt: user.token, name: user.name))
             
@@ -130,6 +134,10 @@ public final class AuthRepositoryImpl: AuthRepository, @unchecked Sendable {
     public func deleteUser() -> Effect<DataResult<String>> {
         
         return Effect.run { [self] send async in
+            guard ConfigManager.shared.hasValidAPIBaseURL else {
+                await send(DataResult(message: ConfigManager.missingAPIBaseURLMessage))
+                return
+            }
             
             let result = await provider.request(.deleteUser)
             

--- a/Projects/Data/AuthData/Sources/Network/AuthAPI.swift
+++ b/Projects/Data/AuthData/Sources/Network/AuthAPI.swift
@@ -9,6 +9,7 @@
 import Moya
 import Foundation
 import AuthDomain
+import Core
 
 enum AuthAPI {
     case login(type: LoginType, jwt: String, name: String)
@@ -23,13 +24,7 @@ extension AuthAPI: TargetType {
     
     
     var baseURL: URL {
-        let url = Bundle.main.object(forInfoDictionaryKey:"BASE_URL")
-        
-        if let urlString = url as? String {
-            return URL(string: urlString)!
-        } else {
-            fatalError("URL String not found")
-        }
+        ConfigManager.shared.apiBaseURL ?? ConfigManager.fallbackBaseURL
     }
     
     var path: String {

--- a/Projects/Data/CalendarData/Project.swift
+++ b/Projects/Data/CalendarData/Project.swift
@@ -6,6 +6,7 @@ let project = Project.configure(
     product: .framework,
     dependencies: [
         .Modules.domain,
+        .Core.core,
         .Core.realmKit,
         .Data.Common.Data,
         .external(name: "RealmSwift"),

--- a/Projects/Data/CalendarData/Sources/CalendarDTO.swift
+++ b/Projects/Data/CalendarData/Sources/CalendarDTO.swift
@@ -52,10 +52,13 @@ public final class TodoDTO: Object, Decodable {
         self.endDate = vo.endDate
         self.isDone = vo.isDone
         self.color = vo.color.toInt()
+        self.shared.append(objectsIn: vo.shared)
     }
     
     public func toVO() -> TodoVO {
-        return TodoVO(id: id, title: title, memo: memo, endDate: endDate, isDone: isDone, color: Color(int:color))
+        var vo = TodoVO(id: id, title: title, memo: memo, endDate: endDate, isDone: isDone, color: Color(int:color))
+        vo.shared = Array(shared)
+        return vo
     }
 }
 
@@ -92,10 +95,13 @@ public final class ScheduleDTO: Object, Decodable {
         self.startDate = vo.startDate
         self.endDate = vo.endDate
         self.color = vo.color.toInt()
+        self.shared.append(objectsIn: vo.shared)
     }
     
     public func toVO() -> ScheduleVO {
-        return ScheduleVO(id: id, title: title, startDate: startDate, endDate: endDate, memo: memo, color: Color(int:color))
+        var vo = ScheduleVO(id: id, title: title, startDate: startDate, endDate: endDate, memo: memo, color: Color(int:color))
+        vo.shared = Array(shared)
+        return vo
     }
 }
 
@@ -120,12 +126,16 @@ public final class DiaryDTO: Object, Decodable {
     
     public init(from vo: DiaryVO) {
         super.init()
+        self.id = vo.id
         self.date = vo.date
         self.content = vo.content
+        self.shared.append(objectsIn: vo.shared)
     }
     
     public func toVO() -> DiaryVO {
-        return DiaryVO(date: date, content: content)
+        var vo = DiaryVO(id: id, date: date, content: content)
+        vo.shared = Array(shared)
+        return vo
     }
 }
 

--- a/Projects/Data/CalendarData/Sources/CalendarRepository.swift
+++ b/Projects/Data/CalendarData/Sources/CalendarRepository.swift
@@ -33,6 +33,11 @@ public final class CalendarRepositoryImpl: CalendarRepository {
     private lazy var session = Session(interceptor: authInterceptor)
 
     private lazy var provider = MoyaProvider<CalendarAPI>(session: session)
+
+    private var shouldUseServer: Bool {
+        let didLogin: Bool? = ConfigManager.shared.get("didLogin")
+        return didLogin == true && ConfigManager.shared.hasValidAPIBaseURL
+    }
     
     public func fetch(for date: Date) -> Effect<CalendarDatas> {
         
@@ -48,8 +53,7 @@ public final class CalendarRepositoryImpl: CalendarRepository {
         
         return Effect.run { [self] send async in
             
-            if let didLogin: Bool = ConfigManager.shared.get("didLogin"),
-               didLogin {
+            if shouldUseServer {
                 let result: Result<Response, MoyaError> = await withCheckedContinuation { continuation in
                     provider.request(.calendar(startDate: startDateString, endDate: endDateString, lastFetch: lastDateString)) { moyaResult in
                         switch moyaResult {
@@ -166,8 +170,7 @@ public final class CalendarRepositoryImpl: CalendarRepository {
             }
         }
         
-        if let didLogin: Bool = ConfigManager.shared.get("didLogin"),
-           didLogin {
+        if shouldUseServer {
             
             if todo.id.isEmpty {
                 provider.request(.createTodo(todo: TodoDTO(from: todo))) { handleTodoResponse($0) }
@@ -218,8 +221,7 @@ public final class CalendarRepositoryImpl: CalendarRepository {
             }
         }
         
-        if let didLogin: Bool = ConfigManager.shared.get("didLogin"),
-           didLogin {
+        if shouldUseServer {
             
             if diary.id.isEmpty {
                 provider.request(.createDiary(diary: DiaryDTO(from: diary))) { handleDiaryResponse($0) }
@@ -267,8 +269,7 @@ public final class CalendarRepositoryImpl: CalendarRepository {
             }
         }
         
-        if let didLogin: Bool = ConfigManager.shared.get("didLogin"),
-           didLogin {
+        if shouldUseServer {
             
             if schedule.id.isEmpty {
                 provider.request(.createSchedule(schedule: ScheduleDTO(from: schedule))) { handleScheduleResponse($0) }
@@ -303,8 +304,7 @@ public final class CalendarRepositoryImpl: CalendarRepository {
     public func deleteTodo(_ id: String) {
         
         if !id.hasPrefix("local_") {
-            if let didLogin: Bool = ConfigManager.shared.get("didLogin"),
-               didLogin {
+            if shouldUseServer {
                 provider.request(.deleteTodo(id: id)) { [self] result in
                     switch result {
                     case .success(let response):
@@ -331,8 +331,7 @@ public final class CalendarRepositoryImpl: CalendarRepository {
     public func deleteDiary(_ id: String) {
         
         if !id.hasPrefix("local_") {
-            if let didLogin: Bool = ConfigManager.shared.get("didLogin"),
-               didLogin {
+            if shouldUseServer {
                 provider.request(.deleteDiary(id: id)) { [self] result in
                     switch result {
                     case .success(let response):
@@ -359,8 +358,7 @@ public final class CalendarRepositoryImpl: CalendarRepository {
     public func deleteSchedule(_ id: String) {
         
         if !id.hasPrefix("local_") {
-            if let didLogin: Bool = ConfigManager.shared.get("didLogin"),
-               didLogin {
+            if shouldUseServer {
                 provider.request(.deleteSchedule(id: id)) { [self] result in
                     switch result {
                     case .success(let response):
@@ -385,6 +383,7 @@ public final class CalendarRepositoryImpl: CalendarRepository {
     }
     
     public func syncServer() {
+        guard ConfigManager.shared.hasValidAPIBaseURL else { return }
         
         let lastDate = authManager.lastLoginDate()
         

--- a/Projects/Data/CalendarData/Sources/CalendarRepository.swift
+++ b/Projects/Data/CalendarData/Sources/CalendarRepository.swift
@@ -38,6 +38,15 @@ public final class CalendarRepositoryImpl: CalendarRepository {
         let didLogin: Bool? = ConfigManager.shared.get("didLogin")
         return didLogin == true && ConfigManager.shared.hasValidAPIBaseURL
     }
+
+    private var activeSharedSpaceId: String? {
+        let id: String? = ConfigManager.shared.get("activeSharedSpaceId")
+        return id?.isEmpty == false ? id : nil
+    }
+
+    private func defaultShared(_ shared: [String]) -> [String] {
+        shared.isEmpty ? activeSharedSpaceId.map { [$0] } ?? [] : shared
+    }
     
     public func fetch(for date: Date) -> Effect<CalendarDatas> {
         
@@ -172,8 +181,12 @@ public final class CalendarRepositoryImpl: CalendarRepository {
         
         if shouldUseServer {
             
+            let shared = defaultShared(todo.shared)
+            var sharedTodo = todo
+            sharedTodo.shared = shared
+
             if todo.id.isEmpty {
-                provider.request(.createTodo(todo: TodoDTO(from: todo))) { handleTodoResponse($0) }
+                provider.request(.createTodo(todo: TodoDTO(from: sharedTodo))) { handleTodoResponse($0) }
             } else {
                 
                 let saved = realmKit.fetchData(type: TodoDTO.self, forKey: todo.id)!
@@ -183,14 +196,16 @@ public final class CalendarRepositoryImpl: CalendarRepository {
                 let endDate = saved.endDate == todo.endDate ? nil : todo.endDate
                 let memo = saved.memo == todo.memo ? nil : todo.memo
                 let color = saved.color == todo.color.toInt() ? nil : todo.color.toInt()
-                let shared = Array(saved.shared) == todo.shared ? nil : todo.shared
+                let shared = Array(saved.shared) == sharedTodo.shared ? nil : sharedTodo.shared
                 
                 provider.request(.updateTodo(id: todo.id, title: title, isDone: isDone, endDate: endDate, memo: memo, color: color, shared: shared)) { handleTodoResponse($0) }
             }
             
         } else {
             
-            let dto = TodoDTO(from:todo)
+            var sharedTodo = todo
+            sharedTodo.shared = defaultShared(todo.shared)
+            let dto = TodoDTO(from: sharedTodo)
             
             if dto.id.isEmpty {
                 dto.id = "local_\(UUID().hashValue)"
@@ -223,22 +238,28 @@ public final class CalendarRepositoryImpl: CalendarRepository {
         
         if shouldUseServer {
             
+            let shared = defaultShared(diary.shared)
+            var sharedDiary = diary
+            sharedDiary.shared = shared
+
             if diary.id.isEmpty {
-                provider.request(.createDiary(diary: DiaryDTO(from: diary))) { handleDiaryResponse($0) }
+                provider.request(.createDiary(diary: DiaryDTO(from: sharedDiary))) { handleDiaryResponse($0) }
             } else {
                 
                 let saved = realmKit.fetchData(type: DiaryDTO.self, forKey: diary.id)!
                 
                 let content: String? = saved.content == diary.content ? nil : diary.content
                 let date = saved.date == diary.date ? nil : diary.date
-                let shared = Array(saved.shared) == diary.shared ? nil : diary.shared
+                let shared = Array(saved.shared) == sharedDiary.shared ? nil : sharedDiary.shared
                 
                 provider.request(.updateDiary(id: diary.id, date: date, content: content, shared: shared)) { handleDiaryResponse($0) }
             }
             
         } else {
             
-            let dto = DiaryDTO(from: diary)
+            var sharedDiary = diary
+            sharedDiary.shared = defaultShared(diary.shared)
+            let dto = DiaryDTO(from: sharedDiary)
             
             if dto.id.isEmpty {
                 dto.id = "local_\(UUID().hashValue)"
@@ -271,8 +292,12 @@ public final class CalendarRepositoryImpl: CalendarRepository {
         
         if shouldUseServer {
             
+            let shared = defaultShared(schedule.shared)
+            var sharedSchedule = schedule
+            sharedSchedule.shared = shared
+
             if schedule.id.isEmpty {
-                provider.request(.createSchedule(schedule: ScheduleDTO(from: schedule))) { handleScheduleResponse($0) }
+                provider.request(.createSchedule(schedule: ScheduleDTO(from: sharedSchedule))) { handleScheduleResponse($0) }
             } else {
                 
                 let saved = realmKit.fetchData(type: ScheduleDTO.self, forKey: schedule.id)!
@@ -282,14 +307,16 @@ public final class CalendarRepositoryImpl: CalendarRepository {
                 let endDate = saved.endDate == schedule.endDate ? nil : schedule.endDate
                 let memo = saved.memo == schedule.memo ? nil : schedule.memo
                 let color = saved.color == schedule.color.toInt() ? nil : schedule.color.toInt()
-                let shared = Array(saved.shared) == schedule.shared ? nil : schedule.shared
+                let shared = Array(saved.shared) == sharedSchedule.shared ? nil : sharedSchedule.shared
                 
                 provider.request(.updateSchedule(id: schedule.id, title: title, startDate: startDate, endDate: endDate, memo: memo, color: color, shared: shared)) { handleScheduleResponse($0) }
             }
             
         } else {
             
-            let dto = ScheduleDTO(from: schedule)
+            var sharedSchedule = schedule
+            sharedSchedule.shared = defaultShared(schedule.shared)
+            let dto = ScheduleDTO(from: sharedSchedule)
             
             if dto.id.isEmpty {
                 dto.id = "local_\(UUID().hashValue)"

--- a/Projects/Data/CalendarData/Sources/Network/CalendarAPI.swift
+++ b/Projects/Data/CalendarData/Sources/Network/CalendarAPI.swift
@@ -9,6 +9,7 @@
 import Moya
 import Foundation
 import Domain
+import Core
 
 enum CalendarAPI {
     case calendar(startDate: String, endDate: String, lastFetch: String)
@@ -35,13 +36,7 @@ extension CalendarAPI: TargetType {
     }
     
     var baseURL: URL {
-        let url = Bundle.main.object(forInfoDictionaryKey:"BASE_URL")
-        
-        if let urlString = url as? String {
-            return URL(string: urlString)!
-        } else {
-            fatalError("URL String not found")
-        }
+        ConfigManager.shared.apiBaseURL ?? ConfigManager.fallbackBaseURL
     }
     
     var path: String {

--- a/Projects/Data/CanvasData/Project.swift
+++ b/Projects/Data/CanvasData/Project.swift
@@ -1,0 +1,12 @@
+import ProjectDescription
+import ProjectDescriptionHelpers
+
+let project = Project.configure(
+    moduleType: .data(name: "Canvas"),
+    product: .framework,
+    dependencies: [
+        .Core.core,
+        .Domains.Canvas.Domain,
+        .external(name: "ComposableArchitecture"),
+    ]
+)

--- a/Projects/Data/CanvasData/Sources/CanvasDTO.swift
+++ b/Projects/Data/CanvasData/Sources/CanvasDTO.swift
@@ -1,0 +1,101 @@
+import Foundation
+import CanvasDomain
+
+public struct CanvasStoreSnapshot: Codable, Equatable {
+    public var canvases: [SharedCanvasDTO]
+    public var strokes: [CanvasStrokeDTO]
+    public var snapshots: [CanvasSnapshotDTO]
+    public var lastSyncedSequenceBySharedSpaceId: [String: Int]
+
+    public init(canvases: [SharedCanvasDTO] = [], strokes: [CanvasStrokeDTO] = [], snapshots: [CanvasSnapshotDTO] = [], lastSyncedSequenceBySharedSpaceId: [String: Int] = [:]) {
+        self.canvases = canvases
+        self.strokes = strokes
+        self.snapshots = snapshots
+        self.lastSyncedSequenceBySharedSpaceId = lastSyncedSequenceBySharedSpaceId
+    }
+}
+
+public struct SharedCanvasDTO: Codable, Equatable {
+    public var id: String
+    public var sharedSpaceId: String
+    public var title: String?
+    public var latestSnapshotVersion: Int
+    public var latestSnapshotUrl: String?
+    public var localSnapshotPath: String?
+
+    public func toVO() -> SharedCanvasVO {
+        SharedCanvasVO(id: id, sharedSpaceId: sharedSpaceId, title: title, latestSnapshotVersion: latestSnapshotVersion, latestSnapshotUrl: latestSnapshotUrl, localSnapshotPath: localSnapshotPath)
+    }
+}
+
+public struct CanvasStrokeDTO: Codable, Equatable {
+    public var id: String
+    public var canvasId: String
+    public var sharedSpaceId: String
+    public var authorId: String
+    public var sequence: Int
+    public var tool: String
+    public var colorHex: String
+    public var lineWidth: Double
+    public var points: [CanvasPointDTO]
+    public var pendingSync: Bool
+
+    public init(_ vo: CanvasStrokeVO, pendingSync: Bool = true) {
+        self.id = vo.id
+        self.canvasId = vo.canvasId
+        self.sharedSpaceId = vo.sharedSpaceId
+        self.authorId = vo.authorId
+        self.sequence = vo.sequence
+        self.tool = vo.tool.rawValue
+        self.colorHex = vo.colorHex
+        self.lineWidth = vo.lineWidth
+        self.points = vo.points.map(CanvasPointDTO.init)
+        self.pendingSync = pendingSync
+    }
+
+    public func toVO() -> CanvasStrokeVO {
+        CanvasStrokeVO(id: id, canvasId: canvasId, sharedSpaceId: sharedSpaceId, authorId: authorId, sequence: sequence, tool: CanvasTool(rawValue: tool) ?? .pen, colorHex: colorHex, lineWidth: lineWidth, points: points.map { $0.toVO() })
+    }
+}
+
+public struct CanvasPointDTO: Codable, Equatable {
+    public var x: Double
+    public var y: Double
+    public var t: Double?
+    public var pressure: Double?
+
+    public init(_ vo: CanvasPointVO) {
+        self.x = vo.x
+        self.y = vo.y
+        self.t = vo.t
+        self.pressure = vo.pressure
+    }
+
+    public func toVO() -> CanvasPointVO { CanvasPointVO(x: x, y: y, t: t, pressure: pressure) }
+}
+
+public struct CanvasSnapshotDTO: Codable, Equatable {
+    public var id: String
+    public var canvasId: String
+    public var sharedSpaceId: String
+    public var version: Int
+    public var imageUrl: String?
+    public var localPath: String?
+    public var width: Int
+    public var height: Int
+
+    public init(_ vo: CanvasSnapshotVO) {
+        self.id = vo.id
+        self.canvasId = vo.canvasId
+        self.sharedSpaceId = vo.sharedSpaceId
+        self.version = vo.version
+        self.imageUrl = vo.imageUrl
+        self.localPath = vo.localPath
+        self.width = vo.width
+        self.height = vo.height
+    }
+
+    public func toVO() -> CanvasSnapshotVO {
+        CanvasSnapshotVO(id: id, canvasId: canvasId, sharedSpaceId: sharedSpaceId, version: version, imageUrl: imageUrl, localPath: localPath, width: width, height: height)
+    }
+}

--- a/Projects/Data/CanvasData/Sources/CanvasRepository.swift
+++ b/Projects/Data/CanvasData/Sources/CanvasRepository.swift
@@ -104,15 +104,22 @@ public final class CanvasRepositoryImpl: CanvasRepository {
         let store = store
         return Effect.run { send in
             var snapshot = store.read()
-            snapshot.snapshots.removeAll { $0.sharedSpaceId == snapshotVO.sharedSpaceId && $0.canvasId == snapshotVO.canvasId }
-            snapshot.snapshots.append(CanvasSnapshotDTO(snapshotVO))
-            if let index = snapshot.canvases.firstIndex(where: { $0.sharedSpaceId == snapshotVO.sharedSpaceId }) {
-                snapshot.canvases[index].latestSnapshotVersion = snapshotVO.version
-                snapshot.canvases[index].latestSnapshotUrl = snapshotVO.imageUrl
-                snapshot.canvases[index].localSnapshotPath = snapshotVO.localPath
+            var storedSnapshot = snapshotVO
+            if let localPath = storedSnapshot.localPath {
+                let sourceURL = URL(fileURLWithPath: localPath)
+                if let appGroupURL = try? CanvasSnapshotFileStore.copyLatestSnapshot(from: sourceURL) {
+                    storedSnapshot = CanvasSnapshotVO(id: snapshotVO.id, canvasId: snapshotVO.canvasId, sharedSpaceId: storedSnapshot.sharedSpaceId, version: storedSnapshot.version, imageUrl: storedSnapshot.imageUrl, localPath: appGroupURL.path, width: snapshotVO.width, height: snapshotVO.height)
+                }
+            }
+            snapshot.snapshots.removeAll { $0.sharedSpaceId == storedSnapshot.sharedSpaceId && $0.canvasId == storedSnapshot.canvasId }
+            snapshot.snapshots.append(CanvasSnapshotDTO(storedSnapshot))
+            if let index = snapshot.canvases.firstIndex(where: { $0.sharedSpaceId == storedSnapshot.sharedSpaceId }) {
+                snapshot.canvases[index].latestSnapshotVersion = storedSnapshot.version
+                snapshot.canvases[index].latestSnapshotUrl = storedSnapshot.imageUrl
+                snapshot.canvases[index].localSnapshotPath = storedSnapshot.localPath
             }
             try? store.write(snapshot)
-            await send(DataResult(isSuccess: true, data: snapshotVO))
+            await send(DataResult(isSuccess: true, data: storedSnapshot))
         }
     }
 

--- a/Projects/Data/CanvasData/Sources/CanvasRepository.swift
+++ b/Projects/Data/CanvasData/Sources/CanvasRepository.swift
@@ -1,0 +1,136 @@
+import Foundation
+import ComposableArchitecture
+import CanvasDomain
+import Core
+
+public final class CanvasJsonStore: @unchecked Sendable {
+    private let fileURL: URL
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
+
+    public init(fileURL: URL = CanvasJsonStore.defaultFileURL()) {
+        self.fileURL = fileURL
+        self.encoder = JSONEncoder()
+        self.encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        self.decoder = JSONDecoder()
+    }
+
+    public static func defaultFileURL() -> URL {
+        FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+            .appendingPathComponent("canvas/canvas_store.json")
+    }
+
+    public func read() -> CanvasStoreSnapshot {
+        guard FileManager.default.fileExists(atPath: fileURL.path) else { return CanvasStoreSnapshot() }
+        return (try? decoder.decode(CanvasStoreSnapshot.self, from: Data(contentsOf: fileURL))) ?? CanvasStoreSnapshot()
+    }
+
+    public func write(_ snapshot: CanvasStoreSnapshot) throws {
+        try FileManager.default.createDirectory(at: fileURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try encoder.encode(snapshot).write(to: fileURL, options: [.atomic])
+    }
+}
+
+public final class CanvasRepositoryImpl: CanvasRepository {
+    private let store: CanvasJsonStore
+    private let idProvider: @Sendable () -> String
+
+    public init(store: CanvasJsonStore = CanvasJsonStore(), idProvider: @escaping @Sendable () -> String = { UUID().uuidString }) {
+        self.store = store
+        self.idProvider = idProvider
+    }
+
+    public func fetchCanvas(sharedSpaceId: String) -> Effect<DataResult<SharedCanvasVO>> {
+        guard let sharedSpaceId = valid(sharedSpaceId) else { return failure("sharedSpaceId is required") }
+        let store = store
+        let idProvider = idProvider
+        return Effect.run { send in
+            var snapshot = store.read()
+            if let canvas = snapshot.canvases.first(where: { $0.sharedSpaceId == sharedSpaceId }) {
+                await send(DataResult(isSuccess: true, data: canvas.toVO()))
+                return
+            }
+            let canvas = SharedCanvasDTO(id: idProvider(), sharedSpaceId: sharedSpaceId, title: "우리 낙서장", latestSnapshotVersion: 0, latestSnapshotUrl: nil, localSnapshotPath: nil)
+            snapshot.canvases.append(canvas)
+            try? store.write(snapshot)
+            await send(DataResult(isSuccess: true, data: canvas.toVO()))
+        }
+    }
+
+    public func fetchStrokes(sharedSpaceId: String, afterSequence: Int?) -> Effect<DataResult<[CanvasStrokeVO]>> {
+        guard let sharedSpaceId = valid(sharedSpaceId) else { return failure("sharedSpaceId is required") }
+        let store = store
+        return Effect.run { send in
+            let strokes = store.read().strokes
+                .filter { $0.sharedSpaceId == sharedSpaceId && (afterSequence == nil || $0.sequence > afterSequence!) }
+                .sorted { $0.sequence < $1.sequence }
+                .map { $0.toVO() }
+            await send(DataResult(isSuccess: true, data: strokes))
+        }
+    }
+
+    public func appendStroke(_ stroke: CanvasStrokeVO) -> Effect<DataResult<CanvasStrokeVO>> {
+        guard valid(stroke.sharedSpaceId) != nil else { return failure("sharedSpaceId is required") }
+        let store = store
+        return Effect.run { send in
+            var snapshot = store.read()
+            snapshot.strokes.removeAll { $0.id == stroke.id }
+            snapshot.strokes.append(CanvasStrokeDTO(stroke, pendingSync: true))
+            try? store.write(snapshot)
+            await send(DataResult(isSuccess: true, data: stroke))
+        }
+    }
+
+    public func clearCanvas(sharedSpaceId: String) -> Effect<DataResult<SharedCanvasVO>> {
+        guard let sharedSpaceId = valid(sharedSpaceId) else { return failure("sharedSpaceId is required") }
+        let store = store
+        let idProvider = idProvider
+        return Effect.run { send in
+            var snapshot = store.read()
+            snapshot.strokes.removeAll { $0.sharedSpaceId == sharedSpaceId }
+            let existing = snapshot.canvases.first(where: { $0.sharedSpaceId == sharedSpaceId })
+            let canvas = SharedCanvasDTO(id: existing?.id ?? idProvider(), sharedSpaceId: sharedSpaceId, title: existing?.title ?? "우리 낙서장", latestSnapshotVersion: (existing?.latestSnapshotVersion ?? 0) + 1, latestSnapshotUrl: nil, localSnapshotPath: existing?.localSnapshotPath)
+            snapshot.canvases.removeAll { $0.sharedSpaceId == sharedSpaceId }
+            snapshot.canvases.append(canvas)
+            try? store.write(snapshot)
+            await send(DataResult(isSuccess: true, data: canvas.toVO()))
+        }
+    }
+
+    public func updateSnapshot(_ snapshotVO: CanvasSnapshotVO) -> Effect<DataResult<CanvasSnapshotVO>> {
+        guard valid(snapshotVO.sharedSpaceId) != nil else { return failure("sharedSpaceId is required") }
+        let store = store
+        return Effect.run { send in
+            var snapshot = store.read()
+            snapshot.snapshots.removeAll { $0.sharedSpaceId == snapshotVO.sharedSpaceId && $0.canvasId == snapshotVO.canvasId }
+            snapshot.snapshots.append(CanvasSnapshotDTO(snapshotVO))
+            if let index = snapshot.canvases.firstIndex(where: { $0.sharedSpaceId == snapshotVO.sharedSpaceId }) {
+                snapshot.canvases[index].latestSnapshotVersion = snapshotVO.version
+                snapshot.canvases[index].latestSnapshotUrl = snapshotVO.imageUrl
+                snapshot.canvases[index].localSnapshotPath = snapshotVO.localPath
+            }
+            try? store.write(snapshot)
+            await send(DataResult(isSuccess: true, data: snapshotVO))
+        }
+    }
+
+    private func valid(_ sharedSpaceId: String) -> String? {
+        let value = sharedSpaceId.trimmingCharacters(in: .whitespacesAndNewlines)
+        return value.isEmpty ? nil : value
+    }
+
+    private func failure<T>(_ message: String) -> Effect<DataResult<T>> {
+        Effect.run { send in await send(DataResult(message: message)) }
+    }
+}
+
+private enum CanvasRepoKey: DependencyKey {
+    static var liveValue: CanvasRepository = CanvasRepositoryImpl()
+}
+
+public extension DependencyValues {
+    var canvasRepository: CanvasRepository {
+        get { self[CanvasRepoKey.self] }
+        set { self[CanvasRepoKey.self] = newValue }
+    }
+}

--- a/Projects/Data/CanvasData/Sources/CanvasRepository.swift
+++ b/Projects/Data/CanvasData/Sources/CanvasRepository.swift
@@ -2,6 +2,7 @@ import Foundation
 import ComposableArchitecture
 import CanvasDomain
 import Core
+import Moya
 
 public final class CanvasJsonStore: @unchecked Sendable {
     private let fileURL: URL
@@ -34,6 +35,7 @@ public final class CanvasJsonStore: @unchecked Sendable {
 public final class CanvasRepositoryImpl: CanvasRepository {
     private let store: CanvasJsonStore
     private let idProvider: @Sendable () -> String
+    private lazy var provider = MoyaProvider<CanvasAPI>()
 
     public init(store: CanvasJsonStore = CanvasJsonStore(), idProvider: @escaping @Sendable () -> String = { UUID().uuidString }) {
         self.store = store
@@ -111,6 +113,37 @@ public final class CanvasRepositoryImpl: CanvasRepository {
             }
             try? store.write(snapshot)
             await send(DataResult(isSuccess: true, data: snapshotVO))
+        }
+    }
+
+    public func pollRemoteStrokes(sharedSpaceId: String, afterSequence: Int?) -> Effect<DataResult<[CanvasStrokeVO]>> {
+        guard let sharedSpaceId = valid(sharedSpaceId) else { return failure("sharedSpaceId is required") }
+        guard ConfigManager.shared.hasValidAPIBaseURL else { return failure(ConfigManager.missingAPIBaseURLMessage) }
+        let localProvider = provider
+        return Effect.run { send in
+            let result = await localProvider.request(.strokes(sharedSpaceId: sharedSpaceId, afterSequence: afterSequence))
+            let mapped: DataResult<[CanvasStrokeVO]> = DataResult(result, dtoType: [CanvasStrokeDTO].self) { $0.map { $0.toVO() } }
+            await send(mapped)
+        }
+    }
+
+    public func appendRemoteStroke(_ stroke: CanvasStrokeVO) -> Effect<DataResult<CanvasStrokeVO>> {
+        guard ConfigManager.shared.hasValidAPIBaseURL else { return failure(ConfigManager.missingAPIBaseURLMessage) }
+        let localProvider = provider
+        return Effect.run { send in
+            let result = await localProvider.request(.appendStroke(sharedSpaceId: stroke.sharedSpaceId, stroke: stroke))
+            let mapped: DataResult<CanvasStrokeVO> = DataResult(result, dtoType: CanvasStrokeDTO.self) { $0.toVO() }
+            await send(mapped)
+        }
+    }
+
+    public func updateRemoteSnapshot(_ snapshot: CanvasSnapshotVO) -> Effect<DataResult<CanvasSnapshotVO>> {
+        guard ConfigManager.shared.hasValidAPIBaseURL else { return failure(ConfigManager.missingAPIBaseURLMessage) }
+        let localProvider = provider
+        return Effect.run { send in
+            let result = await localProvider.request(.updateSnapshot(sharedSpaceId: snapshot.sharedSpaceId, snapshot: snapshot))
+            let mapped: DataResult<CanvasSnapshotVO> = DataResult(result, dtoType: CanvasSnapshotDTO.self) { $0.toVO() }
+            await send(mapped)
         }
     }
 

--- a/Projects/Data/CanvasData/Sources/CanvasSnapshotFileStore.swift
+++ b/Projects/Data/CanvasData/Sources/CanvasSnapshotFileStore.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+public enum CanvasSnapshotFileStore {
+    public static let appGroupIdentifier = "group.com.bongbong.coupleapp"
+    public static let latestFileName = "LiveCanvas/latest_canvas.png"
+
+    public static func appGroupSnapshotURL(fileName: String = latestFileName) -> URL? {
+        FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroupIdentifier)?
+            .appendingPathComponent(fileName)
+    }
+
+    @discardableResult
+    public static func copyLatestSnapshot(from sourceURL: URL, fileName: String = latestFileName) throws -> URL? {
+        guard let destination = appGroupSnapshotURL(fileName: fileName) else { return nil }
+        try FileManager.default.createDirectory(at: destination.deletingLastPathComponent(), withIntermediateDirectories: true)
+        if FileManager.default.fileExists(atPath: destination.path) {
+            try FileManager.default.removeItem(at: destination)
+        }
+        try FileManager.default.copyItem(at: sourceURL, to: destination)
+        return destination
+    }
+}

--- a/Projects/Data/CanvasData/Sources/Network/CanvasAPI.swift
+++ b/Projects/Data/CanvasData/Sources/Network/CanvasAPI.swift
@@ -1,0 +1,55 @@
+import Foundation
+import Moya
+import Core
+import CanvasDomain
+
+enum CanvasAPI {
+    case canvas(sharedSpaceId: String)
+    case appendStroke(sharedSpaceId: String, stroke: CanvasStrokeVO)
+    case strokes(sharedSpaceId: String, afterSequence: Int?)
+    case clear(sharedSpaceId: String)
+    case updateSnapshot(sharedSpaceId: String, snapshot: CanvasSnapshotVO)
+    case snapshot(sharedSpaceId: String)
+}
+
+extension CanvasAPI: TargetType {
+    var baseURL: URL { ConfigManager.shared.apiBaseURL ?? ConfigManager.fallbackBaseURL }
+
+    var path: String {
+        switch self {
+        case .canvas(let sharedSpaceId):
+            return "/shared-spaces/\(sharedSpaceId)/canvas"
+        case .appendStroke(let sharedSpaceId, _):
+            return "/shared-spaces/\(sharedSpaceId)/canvas/strokes"
+        case .strokes(let sharedSpaceId, _):
+            return "/shared-spaces/\(sharedSpaceId)/canvas/strokes"
+        case .clear(let sharedSpaceId):
+            return "/shared-spaces/\(sharedSpaceId)/canvas/clear"
+        case .updateSnapshot(let sharedSpaceId, _), .snapshot(let sharedSpaceId):
+            return "/shared-spaces/\(sharedSpaceId)/canvas/snapshot"
+        }
+    }
+
+    var method: Moya.Method {
+        switch self {
+        case .canvas, .strokes, .snapshot: return .get
+        case .appendStroke, .clear, .updateSnapshot: return .post
+        }
+    }
+
+    var task: Task {
+        switch self {
+        case .strokes(_, let afterSequence):
+            guard let afterSequence else { return .requestPlain }
+            return .requestParameters(parameters: ["afterSequence": afterSequence], encoding: URLEncoding.queryString)
+        case .appendStroke(_, let stroke):
+            return .requestJSONEncodable(CanvasStrokeDTO(stroke))
+        case .updateSnapshot(_, let snapshot):
+            return .requestJSONEncodable(CanvasSnapshotDTO(snapshot))
+        default:
+            return .requestPlain
+        }
+    }
+
+    var headers: [String : String]? { ["Content-Type": "application/json"] }
+}

--- a/Projects/Data/CommonData/Sources/AuthInterceptor.swift
+++ b/Projects/Data/CommonData/Sources/AuthInterceptor.swift
@@ -16,10 +16,9 @@ public final class AuthInterceptor: RequestInterceptor {
     
     @Dependency(\.authManager) var authManager
     
-    private let url = Bundle.main.object(forInfoDictionaryKey:"BASE_URL")
-    
     public func adapt(_ urlRequest: URLRequest, for session: Session, completion: @escaping (Result<URLRequest, Error>) -> Void) {
-        guard urlRequest.url?.absoluteString.hasPrefix(url as! String) == true
+        guard let apiBaseURL = ConfigManager.shared.apiBaseURL,
+              urlRequest.url?.absoluteString.hasPrefix(apiBaseURL.absoluteString) == true
         else {
             completion(.success(urlRequest))
             return

--- a/Projects/Data/CommonData/Sources/Network/RefreshAPI.swift
+++ b/Projects/Data/CommonData/Sources/Network/RefreshAPI.swift
@@ -8,6 +8,7 @@
 
 import Moya
 import Foundation
+import Core
 
 enum RefreshAPI {
     case refresh(token: String)
@@ -20,13 +21,7 @@ extension RefreshAPI: TargetType {
     
     
     var baseURL: URL {
-        let url = Bundle.main.object(forInfoDictionaryKey:"BASE_URL")
-        
-        if let urlString = url as? String {
-            return URL(string: urlString)!
-        } else {
-            fatalError("URL String not found")
-        }
+        ConfigManager.shared.apiBaseURL ?? ConfigManager.fallbackBaseURL
     }
     
     var path: String {

--- a/Projects/Data/FriendData/Sources/FriendDTO.swift
+++ b/Projects/Data/FriendData/Sources/FriendDTO.swift
@@ -25,3 +25,25 @@ struct FriendInviteDTO: Codable {
     var intiteUrl: String
     var expiresAt: Date
 }
+
+struct SharedSpaceDTO: Codable {
+    var id: String
+    var type: String
+    var name: String?
+    var members: [SharedSpaceMemberDTO]
+    var createdAt: Date?
+    var updatedAt: Date?
+}
+
+struct SharedSpaceMemberDTO: Codable {
+    var userId: String
+    var name: String
+    var role: String
+}
+
+struct PairingInviteDTO: Codable {
+    var code: String
+    var sharedSpaceId: String?
+    var inviterId: String
+    var expiresAt: Date?
+}

--- a/Projects/Data/FriendData/Sources/FriendRepository.swift
+++ b/Projects/Data/FriendData/Sources/FriendRepository.swift
@@ -18,8 +18,17 @@ public final class FriendRepositoryImpl: FriendRepository {
     private lazy var session = Session(interceptor: authInterceptor)
 
     private lazy var provider = MoyaProvider<FriendAPI>(session: session)
+
+    private func unavailableBaseURLResult<T>() -> Effect<DataResult<T>> {
+        Effect.run { send in
+            await send(DataResult(message: ConfigManager.missingAPIBaseURLMessage))
+        }
+    }
     
     public func fetch() -> Effect<DataResult<[FriendVO]>> {
+        guard ConfigManager.shared.hasValidAPIBaseURL else {
+            return unavailableBaseURLResult()
+        }
         
         let localProvider = provider
         
@@ -36,6 +45,10 @@ public final class FriendRepositoryImpl: FriendRepository {
     }
     
     public func fetchRequests() -> Effect<DataResult<[FriendRequestVO]>> {
+        guard ConfigManager.shared.hasValidAPIBaseURL else {
+            return unavailableBaseURLResult()
+        }
+
         let localProvider = provider
         
         return Effect.run { send in
@@ -51,6 +64,10 @@ public final class FriendRepositoryImpl: FriendRepository {
     }
     
     public func friendRequest(_ uid: String) -> Effect<DataResult<FriendRequestVO>> {
+        guard ConfigManager.shared.hasValidAPIBaseURL else {
+            return unavailableBaseURLResult()
+        }
+
         let localProvider = provider
         
         return Effect.run { send in
@@ -68,6 +85,10 @@ public final class FriendRepositoryImpl: FriendRepository {
     }
     
     public func acceptFriend(_ id: String) -> Effect<DataResult<FriendVO>> {
+        guard ConfigManager.shared.hasValidAPIBaseURL else {
+            return unavailableBaseURLResult()
+        }
+
         let localProvider = provider
         
         return Effect.run { send in
@@ -82,6 +103,10 @@ public final class FriendRepositoryImpl: FriendRepository {
     }
     
     public func rejectFriend(_ id: String) -> Effect<DataResult<FriendVO>> {
+        guard ConfigManager.shared.hasValidAPIBaseURL else {
+            return unavailableBaseURLResult()
+        }
+
         let localProvider = provider
         
         return Effect.run { send in
@@ -96,6 +121,10 @@ public final class FriendRepositoryImpl: FriendRepository {
     }
     
     public func deleteFriend(_ id: String) -> Effect<DataResult<FriendVO>> {
+        guard ConfigManager.shared.hasValidAPIBaseURL else {
+            return unavailableBaseURLResult()
+        }
+
         let localProvider = provider
         
         return Effect.run { send in

--- a/Projects/Data/FriendData/Sources/FriendRepository.swift
+++ b/Projects/Data/FriendData/Sources/FriendRepository.swift
@@ -24,6 +24,32 @@ public final class FriendRepositoryImpl: FriendRepository {
             await send(DataResult(message: ConfigManager.missingAPIBaseURLMessage))
         }
     }
+
+    private func mapSharedSpace(_ dto: SharedSpaceDTO) -> SharedSpaceVO {
+        SharedSpaceVO(
+            id: dto.id,
+            type: SharedSpaceType(rawValue: dto.type) ?? .pair,
+            name: dto.name,
+            members: dto.members.map { member in
+                SharedSpaceMemberVO(
+                    userId: member.userId,
+                    name: member.name,
+                    role: SharedSpaceMemberRole(rawValue: member.role) ?? .member
+                )
+            },
+            createdAt: dto.createdAt,
+            updatedAt: dto.updatedAt
+        )
+    }
+
+    private func mapPairingInvite(_ dto: PairingInviteDTO) -> PairingInviteVO {
+        PairingInviteVO(
+            code: dto.code,
+            sharedSpaceId: dto.sharedSpaceId,
+            inviterId: dto.inviterId,
+            expiresAt: dto.expiresAt
+        )
+    }
     
     public func fetch() -> Effect<DataResult<[FriendVO]>> {
         guard ConfigManager.shared.hasValidAPIBaseURL else {
@@ -134,6 +160,94 @@ public final class FriendRepositoryImpl: FriendRepository {
                 FriendVO(id: dto.id, name: dto.name)
             }
             
+            await send(dataResult)
+        }
+    }
+
+    public func fetchActiveSharedSpace() -> Effect<DataResult<SharedSpaceVO?>> {
+        guard ConfigManager.shared.hasValidAPIBaseURL else {
+            return unavailableBaseURLResult()
+        }
+
+        let localProvider = provider
+        let mapSharedSpace = self.mapSharedSpace
+
+        return Effect.run { send in
+            let moyaResult = await localProvider.request(.activeSharedSpace)
+
+            let dataResult: DataResult<SharedSpaceVO?> = DataResult(moyaResult, dtoType: SharedSpaceDTO?.self) { dto in
+                dto.map(mapSharedSpace)
+            }
+
+            if let sharedSpace = dataResult.data ?? nil {
+                ConfigManager.shared.set("activeSharedSpaceId", sharedSpace.id)
+            }
+
+            await send(dataResult)
+        }
+    }
+
+    public func createPairingInvite() -> Effect<DataResult<PairingInviteVO>> {
+        guard ConfigManager.shared.hasValidAPIBaseURL else {
+            return unavailableBaseURLResult()
+        }
+
+        let localProvider = provider
+        let mapPairingInvite = self.mapPairingInvite
+
+        return Effect.run { send in
+            let moyaResult = await localProvider.request(.createPairingInvite)
+
+            let dataResult: DataResult<PairingInviteVO> = DataResult(moyaResult, dtoType: PairingInviteDTO.self) { dto in
+                mapPairingInvite(dto)
+            }
+
+            await send(dataResult)
+        }
+    }
+
+    public func acceptPairingInvite(_ code: String) -> Effect<DataResult<SharedSpaceVO>> {
+        guard ConfigManager.shared.hasValidAPIBaseURL else {
+            return unavailableBaseURLResult()
+        }
+
+        let localProvider = provider
+        let mapSharedSpace = self.mapSharedSpace
+
+        return Effect.run { send in
+            let moyaResult = await localProvider.request(.acceptPairingInvite(code: code))
+
+            let dataResult: DataResult<SharedSpaceVO> = DataResult(moyaResult, dtoType: SharedSpaceDTO.self) { dto in
+                mapSharedSpace(dto)
+            }
+
+            if let sharedSpace = dataResult.data {
+                ConfigManager.shared.set("activeSharedSpaceId", sharedSpace.id)
+            }
+
+            await send(dataResult)
+        }
+    }
+
+    public func leaveSharedSpace(_ id: String) -> Effect<DataResult<SharedSpaceVO>> {
+        guard ConfigManager.shared.hasValidAPIBaseURL else {
+            return unavailableBaseURLResult()
+        }
+
+        let localProvider = provider
+        let mapSharedSpace = self.mapSharedSpace
+
+        return Effect.run { send in
+            let moyaResult = await localProvider.request(.leaveSharedSpace(id: id))
+
+            let dataResult: DataResult<SharedSpaceVO> = DataResult(moyaResult, dtoType: SharedSpaceDTO.self) { dto in
+                mapSharedSpace(dto)
+            }
+
+            if dataResult.isSuccess {
+                ConfigManager.shared.set("activeSharedSpaceId", "")
+            }
+
             await send(dataResult)
         }
     }

--- a/Projects/Data/FriendData/Sources/Network/FriendAPI.swift
+++ b/Projects/Data/FriendData/Sources/Network/FriendAPI.swift
@@ -17,6 +17,10 @@ enum FriendAPI {
     case request(uid: String)
     case acceptFriend(friendId: String)
     case deleteFriend(friendId: String)
+    case activeSharedSpace
+    case createPairingInvite
+    case acceptPairingInvite(code: String)
+    case leaveSharedSpace(id: String)
 }
 
 
@@ -43,6 +47,14 @@ extension FriendAPI: TargetType {
             return "/friend/accept/\(friendId)"
         case .deleteFriend(friendId: let friendId):
             return "/friend/\(friendId)"
+        case .activeSharedSpace:
+            return "/shared-spaces/active"
+        case .createPairingInvite:
+            return "/shared-spaces/invites"
+        case .acceptPairingInvite(code: let code):
+            return "/shared-spaces/invites/\(code)/accept"
+        case .leaveSharedSpace(id: let id):
+            return "/shared-spaces/\(id)/members/me"
         }
     }
     
@@ -60,6 +72,14 @@ extension FriendAPI: TargetType {
             return .post
         case .deleteFriend(friendId: _):
             return .delete
+        case .activeSharedSpace:
+            return .get
+        case .createPairingInvite:
+            return .post
+        case .acceptPairingInvite(code: _):
+            return .post
+        case .leaveSharedSpace(id: _):
+            return .delete
         }
     }
     
@@ -76,6 +96,14 @@ extension FriendAPI: TargetType {
         case .acceptFriend:
             return .requestPlain
         case .deleteFriend:
+            return .requestPlain
+        case .activeSharedSpace:
+            return .requestPlain
+        case .createPairingInvite:
+            return .requestPlain
+        case .acceptPairingInvite:
+            return .requestPlain
+        case .leaveSharedSpace:
             return .requestPlain
         }
     }

--- a/Projects/Data/FriendData/Sources/Network/FriendAPI.swift
+++ b/Projects/Data/FriendData/Sources/Network/FriendAPI.swift
@@ -8,6 +8,7 @@
 
 import Moya
 import Foundation
+import Core
 
 enum FriendAPI {
     case friends
@@ -25,13 +26,7 @@ extension FriendAPI: TargetType {
     }
     
     var baseURL: URL {
-        let url = Bundle.main.object(forInfoDictionaryKey:"BASE_URL")
-        
-        if let urlString = url as? String {
-            return URL(string: urlString)!
-        } else {
-            fatalError("URL String not found")
-        }
+        ConfigManager.shared.apiBaseURL ?? ConfigManager.fallbackBaseURL
     }
     
     var path: String {

--- a/Projects/Domains/CanvasDomain/Project.swift
+++ b/Projects/Domains/CanvasDomain/Project.swift
@@ -1,0 +1,11 @@
+import ProjectDescription
+import ProjectDescriptionHelpers
+
+let project = Project.configure(
+    moduleType: .domain(name: "Canvas"),
+    product: .framework,
+    dependencies: [
+        .Core.core,
+        .external(name: "ComposableArchitecture"),
+    ]
+)

--- a/Projects/Domains/CanvasDomain/Sources/CanvasRepository.swift
+++ b/Projects/Domains/CanvasDomain/Sources/CanvasRepository.swift
@@ -1,0 +1,10 @@
+import ComposableArchitecture
+import Core
+
+public protocol CanvasRepository {
+    func fetchCanvas(sharedSpaceId: String) -> Effect<DataResult<SharedCanvasVO>>
+    func fetchStrokes(sharedSpaceId: String, afterSequence: Int?) -> Effect<DataResult<[CanvasStrokeVO]>>
+    func appendStroke(_ stroke: CanvasStrokeVO) -> Effect<DataResult<CanvasStrokeVO>>
+    func clearCanvas(sharedSpaceId: String) -> Effect<DataResult<SharedCanvasVO>>
+    func updateSnapshot(_ snapshot: CanvasSnapshotVO) -> Effect<DataResult<CanvasSnapshotVO>>
+}

--- a/Projects/Domains/CanvasDomain/Sources/CanvasVO.swift
+++ b/Projects/Domains/CanvasDomain/Sources/CanvasVO.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+public struct SharedCanvasVO: Equatable, Sendable, Codable {
+    public let id: String
+    public let sharedSpaceId: String
+    public let title: String?
+    public let latestSnapshotVersion: Int
+    public let latestSnapshotUrl: String?
+    public let localSnapshotPath: String?
+
+    public init(id: String, sharedSpaceId: String, title: String? = nil, latestSnapshotVersion: Int = 0, latestSnapshotUrl: String? = nil, localSnapshotPath: String? = nil) {
+        self.id = id
+        self.sharedSpaceId = sharedSpaceId
+        self.title = title
+        self.latestSnapshotVersion = latestSnapshotVersion
+        self.latestSnapshotUrl = latestSnapshotUrl
+        self.localSnapshotPath = localSnapshotPath
+    }
+}
+
+public struct CanvasStrokeVO: Equatable, Sendable, Identifiable, Codable {
+    public let id: String
+    public let canvasId: String
+    public let sharedSpaceId: String
+    public let authorId: String
+    public let sequence: Int
+    public let tool: CanvasTool
+    public let colorHex: String
+    public let lineWidth: Double
+    public let points: [CanvasPointVO]
+
+    public init(id: String, canvasId: String, sharedSpaceId: String, authorId: String, sequence: Int, tool: CanvasTool, colorHex: String, lineWidth: Double, points: [CanvasPointVO]) {
+        self.id = id
+        self.canvasId = canvasId
+        self.sharedSpaceId = sharedSpaceId
+        self.authorId = authorId
+        self.sequence = sequence
+        self.tool = tool
+        self.colorHex = colorHex
+        self.lineWidth = lineWidth
+        self.points = points.map { $0.normalized() }
+    }
+}
+
+public enum CanvasTool: String, Equatable, Sendable, Codable {
+    case pen
+    case eraser
+}
+
+public struct CanvasPointVO: Equatable, Sendable, Codable {
+    public let x: Double
+    public let y: Double
+    public let t: Double?
+    public let pressure: Double?
+
+    public init(x: Double, y: Double, t: Double? = nil, pressure: Double? = nil) {
+        self.x = min(max(x, 0), 1)
+        self.y = min(max(y, 0), 1)
+        self.t = t
+        self.pressure = pressure.map { min(max($0, 0), 1) }
+    }
+
+    public func normalized() -> CanvasPointVO {
+        CanvasPointVO(x: x, y: y, t: t, pressure: pressure)
+    }
+}
+
+public struct CanvasSnapshotVO: Equatable, Sendable, Codable {
+    public let id: String
+    public let canvasId: String
+    public let sharedSpaceId: String
+    public let version: Int
+    public let imageUrl: String?
+    public let localPath: String?
+    public let width: Int
+    public let height: Int
+
+    public init(id: String, canvasId: String, sharedSpaceId: String, version: Int, imageUrl: String? = nil, localPath: String? = nil, width: Int, height: Int) {
+        self.id = id
+        self.canvasId = canvasId
+        self.sharedSpaceId = sharedSpaceId
+        self.version = version
+        self.imageUrl = imageUrl
+        self.localPath = localPath
+        self.width = width
+        self.height = height
+    }
+}

--- a/Projects/Domains/Domain/Tests/Sources/CalendarDomainTests.swift
+++ b/Projects/Domains/Domain/Tests/Sources/CalendarDomainTests.swift
@@ -1,0 +1,30 @@
+import Foundation
+import SwiftUI
+import Testing
+@testable import Domain
+
+struct CalendarDomainTests {
+    @Test
+    func scheduleDateKeysIncludeEveryDayInRange() throws {
+        let calendar = Calendar(identifier: .gregorian)
+        let startDate = try #require(calendar.date(from: DateComponents(year: 2026, month: 5, day: 8)))
+        let endDate = try #require(calendar.date(from: DateComponents(year: 2026, month: 5, day: 10)))
+        let schedule = ScheduleVO(
+            title: "여행",
+            startDate: startDate,
+            endDate: endDate,
+            memo: "",
+            color: .red
+        )
+
+        #expect(schedule.dateKeys() == ["20260508", "20260509", "20260510"])
+    }
+
+    @Test
+    func colorHexRoundTripsToInt() {
+        let color = Color(int: 0xAA7733)
+
+        #expect(color.toHex() == "AA7733")
+        #expect(color.toInt() == 0xAA7733)
+    }
+}

--- a/Projects/Domains/FriendDomain/Sources/FriendRepository.swift
+++ b/Projects/Domains/FriendDomain/Sources/FriendRepository.swift
@@ -17,4 +17,9 @@ public protocol FriendRepository {
     func acceptFriend(_ id: String) -> Effect<DataResult<FriendVO>>
     func rejectFriend(_ id: String) -> Effect<DataResult<FriendVO>>
     func deleteFriend(_ id: String) -> Effect<DataResult<FriendVO>>
+
+    func fetchActiveSharedSpace() -> Effect<DataResult<SharedSpaceVO?>>
+    func createPairingInvite() -> Effect<DataResult<PairingInviteVO>>
+    func acceptPairingInvite(_ code: String) -> Effect<DataResult<SharedSpaceVO>>
+    func leaveSharedSpace(_ id: String) -> Effect<DataResult<SharedSpaceVO>>
 }

--- a/Projects/Domains/FriendDomain/Sources/SharedSpaceVO.swift
+++ b/Projects/Domains/FriendDomain/Sources/SharedSpaceVO.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+public struct SharedSpaceVO: Equatable, Sendable {
+    public let id: String
+    public let type: SharedSpaceType
+    public let name: String?
+    public let members: [SharedSpaceMemberVO]
+    public let createdAt: Date?
+    public let updatedAt: Date?
+
+    public init(
+        id: String,
+        type: SharedSpaceType = .pair,
+        name: String? = nil,
+        members: [SharedSpaceMemberVO] = [],
+        createdAt: Date? = nil,
+        updatedAt: Date? = nil
+    ) {
+        self.id = id
+        self.type = type
+        self.name = name
+        self.members = members
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+}
+
+public enum SharedSpaceType: String, Equatable, Sendable {
+    case pair
+}
+
+public struct SharedSpaceMemberVO: Equatable, Sendable {
+    public let userId: String
+    public let name: String
+    public let role: SharedSpaceMemberRole
+
+    public init(userId: String, name: String, role: SharedSpaceMemberRole = .member) {
+        self.userId = userId
+        self.name = name
+        self.role = role
+    }
+}
+
+public enum SharedSpaceMemberRole: String, Equatable, Sendable {
+    case owner
+    case member
+}
+
+public struct PairingInviteVO: Equatable, Sendable {
+    public let code: String
+    public let sharedSpaceId: String?
+    public let inviterId: String
+    public let expiresAt: Date?
+
+    public init(code: String, sharedSpaceId: String? = nil, inviterId: String, expiresAt: Date? = nil) {
+        self.code = code
+        self.sharedSpaceId = sharedSpaceId
+        self.inviterId = inviterId
+        self.expiresAt = expiresAt
+    }
+}

--- a/Projects/Features/CanvasFeature/Interface/Sources/CanvasInterface.swift
+++ b/Projects/Features/CanvasFeature/Interface/Sources/CanvasInterface.swift
@@ -1,0 +1,5 @@
+import SwiftUI
+
+public protocol CanvasInterface {
+    func makeView() -> any View
+}

--- a/Projects/Features/CanvasFeature/Project.swift
+++ b/Projects/Features/CanvasFeature/Project.swift
@@ -1,0 +1,14 @@
+import ProjectDescription
+import ProjectDescriptionHelpers
+
+let project = Project.configure(
+    moduleType: .feature(name: "Canvas", type: .micro),
+    product: .framework,
+    dependencies: [
+        .Core.core,
+        .Data.Canvas.Data,
+        .Domains.Canvas.Domain,
+        .external(name: "ComposableArchitecture"),
+    ],
+    interfaceDependencies: []
+)

--- a/Projects/Features/CanvasFeature/Sources/CanvasReducer.swift
+++ b/Projects/Features/CanvasFeature/Sources/CanvasReducer.swift
@@ -1,0 +1,134 @@
+import Foundation
+import ComposableArchitecture
+import CanvasData
+import CanvasDomain
+import Core
+
+@Reducer
+public struct CanvasReducer {
+    @Dependency(\.canvasRepository) var canvasRepository
+
+    public init() {}
+
+    @ObservableState
+    public struct State: Equatable {
+        public var activeSharedSpaceId: String?
+        public var canvas: SharedCanvasVO?
+        public var strokes: [CanvasStrokeVO] = []
+        public var currentStroke: CanvasStrokeVO?
+        public var selectedTool: CanvasTool = .pen
+        public var selectedColorHex: String = "#3D2C2E"
+        public var lineWidth: Double = 6
+        public var errorMessage: String?
+        public var snapshotUpdater = ThrottledSnapshotUpdater(minimumInterval: 2)
+
+        public init(activeSharedSpaceId: String? = ConfigManager.shared.get("activeSharedSpaceId")) {
+            self.activeSharedSpaceId = activeSharedSpaceId
+        }
+    }
+
+    public enum Action: BindableAction, Equatable {
+        case binding(BindingAction<State>)
+        case onAppear
+        case startStroke(CanvasPointVO)
+        case appendPoint(CanvasPointVO)
+        case endStroke
+        case clearTapped
+        case didLoadCanvas(SharedCanvasVO)
+        case didLoadStrokes([CanvasStrokeVO])
+        case didAppendStroke(CanvasStrokeVO)
+        case didUpdateSnapshot(CanvasSnapshotVO)
+        case setTool(CanvasTool)
+        case setColor(String)
+        case setLineWidth(Double)
+        case showError(String)
+    }
+
+    public var body: some ReducerOf<Self> {
+        BindingReducer()
+        Reduce { state, action in
+            switch action {
+            case .binding:
+                return .none
+            case .onAppear:
+                guard let sharedSpaceId = state.activeSharedSpaceId?.trimmingCharacters(in: .whitespacesAndNewlines), !sharedSpaceId.isEmpty else {
+                    state.errorMessage = "페어링 후 우리 낙서장을 사용할 수 있어요."
+                    return .none
+                }
+                return .merge(
+                    canvasRepository.fetchCanvas(sharedSpaceId: sharedSpaceId).map { @Sendable result in
+                        result.isSuccess ? .didLoadCanvas(result.data!) : .showError(result.message)
+                    },
+                    canvasRepository.fetchStrokes(sharedSpaceId: sharedSpaceId, afterSequence: nil).map { @Sendable result in
+                        result.isSuccess ? .didLoadStrokes(result.data ?? []) : .showError(result.message)
+                    }
+                )
+            case .didLoadCanvas(let canvas):
+                state.canvas = canvas
+                state.errorMessage = nil
+                return .none
+            case .didLoadStrokes(let strokes):
+                state.strokes = strokes
+                return .none
+            case .startStroke(let point):
+                guard let sharedSpaceId = state.activeSharedSpaceId, let canvasId = state.canvas?.id else { return .send(.showError("페어링 후 우리 낙서장을 사용할 수 있어요.")) }
+                let sequence = (state.strokes.map(\.sequence).max() ?? 0) + 1
+                state.currentStroke = CanvasStrokeVO(
+                    id: UUID().uuidString,
+                    canvasId: canvasId,
+                    sharedSpaceId: sharedSpaceId,
+                    authorId: "local",
+                    sequence: sequence,
+                    tool: state.selectedTool,
+                    colorHex: state.selectedColorHex,
+                    lineWidth: state.lineWidth,
+                    points: [point]
+                )
+                return .none
+            case .appendPoint(let point):
+                guard let current = state.currentStroke else { return .none }
+                state.currentStroke = CanvasStrokeVO(
+                    id: current.id,
+                    canvasId: current.canvasId,
+                    sharedSpaceId: current.sharedSpaceId,
+                    authorId: current.authorId,
+                    sequence: current.sequence,
+                    tool: current.tool,
+                    colorHex: current.colorHex,
+                    lineWidth: current.lineWidth,
+                    points: current.points + [point]
+                )
+                return .none
+            case .endStroke:
+                guard let stroke = state.currentStroke else { return .none }
+                state.currentStroke = nil
+                state.strokes.append(stroke)
+                return canvasRepository.appendStroke(stroke).map { @Sendable result in
+                    result.isSuccess ? .didAppendStroke(result.data!) : .showError(result.message)
+                }
+            case .didAppendStroke:
+                return .none
+            case .clearTapped:
+                guard let sharedSpaceId = state.activeSharedSpaceId else { return .none }
+                state.strokes = []
+                return canvasRepository.clearCanvas(sharedSpaceId: sharedSpaceId).map { @Sendable result in
+                    result.isSuccess ? .didLoadCanvas(result.data!) : .showError(result.message)
+                }
+            case .didUpdateSnapshot:
+                return .none
+            case .setTool(let tool):
+                state.selectedTool = tool
+                return .none
+            case .setColor(let color):
+                state.selectedColorHex = color
+                return .none
+            case .setLineWidth(let width):
+                state.lineWidth = width
+                return .none
+            case .showError(let message):
+                state.errorMessage = message
+                return .none
+            }
+        }
+    }
+}

--- a/Projects/Features/CanvasFeature/Sources/CanvasView.swift
+++ b/Projects/Features/CanvasFeature/Sources/CanvasView.swift
@@ -1,0 +1,98 @@
+import SwiftUI
+import ComposableArchitecture
+import CanvasDomain
+import CanvasFeatureInterface
+import Core
+
+public struct CanvasView: View {
+    @Bindable var store: StoreOf<CanvasReducer>
+
+    public init(store: StoreOf<CanvasReducer>) { self.store = store }
+
+    public var body: some View {
+        VStack(spacing: 12) {
+            if let message = store.errorMessage, store.activeSharedSpaceId == nil {
+                ContentUnavailableView("우리 낙서장", systemImage: "heart.text.square", description: Text(message))
+            } else {
+                DrawingSurface(strokes: store.strokes, currentStroke: store.currentStroke)
+                    .gesture(
+                        DragGesture(minimumDistance: 0)
+                            .onChanged { value in
+                                let point = CanvasPointVO(x: value.location.x / max(value.startLocation.x + abs(value.translation.width), 1), y: value.location.y / max(value.startLocation.y + abs(value.translation.height), 1), t: Date().timeIntervalSince1970, pressure: nil)
+                                if store.currentStroke == nil { store.send(.startStroke(point)) } else { store.send(.appendPoint(point)) }
+                            }
+                            .onEnded { _ in store.send(.endStroke) }
+                    )
+                    .background(Color.mbBackgroundBeige)
+                    .clipShape(RoundedRectangle(cornerRadius: 24))
+                    .padding()
+
+                HStack {
+                    Button("펜") { store.send(.setTool(.pen)) }
+                    Button("지우개") { store.send(.setTool(.eraser)) }
+                    ColorPicker("색", selection: Binding(get: { Color(hex: store.selectedColorHex) }, set: { store.send(.setColor($0.hexString)) }))
+                    Slider(value: $store.lineWidth.sending(\.setLineWidth), in: 2...24)
+                    Button("전체 지우기") { store.send(.clearTapped) }
+                }
+                .padding(.horizontal)
+            }
+        }
+        .navigationTitle("우리 낙서장")
+        .onAppear { store.send(.onAppear) }
+    }
+}
+
+private struct DrawingSurface: View {
+    let strokes: [CanvasStrokeVO]
+    let currentStroke: CanvasStrokeVO?
+
+    var body: some View {
+        Canvas { context, size in
+            for stroke in (strokes + [currentStroke].compactMap { $0 }).sorted(by: { $0.sequence < $1.sequence }) {
+                var path = Path()
+                guard let first = stroke.points.first else { continue }
+                path.move(to: CGPoint(x: first.x * size.width, y: first.y * size.height))
+                for point in stroke.points.dropFirst() {
+                    path.addLine(to: CGPoint(x: point.x * size.width, y: point.y * size.height))
+                }
+                context.stroke(path, with: .color(stroke.tool == .eraser ? .mbBackgroundBeige : Color(hex: stroke.colorHex)), style: StrokeStyle(lineWidth: stroke.lineWidth, lineCap: .round, lineJoin: .round))
+            }
+        }
+        .frame(minHeight: 420)
+    }
+}
+
+public struct CanvasFeature: CanvasInterface {
+    private let store: StoreOf<CanvasReducer>
+
+    public init() {
+        self.store = Store(initialState: CanvasReducer.State()) { CanvasReducer() }
+    }
+
+    public func makeView() -> any View { AnyView(CanvasView(store: store)) }
+}
+
+enum CanvasFeatureKey: DependencyKey {
+    static var liveValue: CanvasInterface = CanvasFeature()
+}
+
+public extension DependencyValues {
+    var canvasFeature: CanvasInterface {
+        get { self[CanvasFeatureKey.self] }
+        set { self[CanvasFeatureKey.self] = newValue }
+    }
+}
+
+private extension Color {
+    init(hex: String) {
+        let cleaned = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+        var int: UInt64 = 0
+        Scanner(string: cleaned).scanHexInt64(&int)
+        let r = Double((int >> 16) & 0xff) / 255
+        let g = Double((int >> 8) & 0xff) / 255
+        let b = Double(int & 0xff) / 255
+        self.init(red: r, green: g, blue: b)
+    }
+
+    var hexString: String { "#3D2C2E" }
+}

--- a/Projects/Features/CanvasFeature/Tests/Sources/CanvasReducerTests.swift
+++ b/Projects/Features/CanvasFeature/Tests/Sources/CanvasReducerTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+import ComposableArchitecture
+@testable import CanvasFeature
+import CanvasDomain
+import Core
+
+@MainActor
+final class CanvasReducerTests: XCTestCase {
+    func testOnAppearWithoutSharedSpaceShowsPairingMessage() async {
+        let store = TestStore(initialState: CanvasReducer.State(activeSharedSpaceId: nil)) {
+            CanvasReducer()
+        }
+
+        await store.send(.onAppear) {
+            $0.errorMessage = "페어링 후 우리 낙서장을 사용할 수 있어요."
+        }
+    }
+}

--- a/Projects/Features/FriendFeature/Project.swift
+++ b/Projects/Features/FriendFeature/Project.swift
@@ -7,6 +7,7 @@ let project = Project.configure(
     dependencies: [
         .Core.core,
         .Data.Friend.Data,
-        .Domains.Friend.Domain
+        .Domains.Friend.Domain,
+        .external(name: "ComposableArchitecture")
     ]
 )

--- a/Projects/Features/FriendFeature/Sources/FriendReducer.swift
+++ b/Projects/Features/FriendFeature/Sources/FriendReducer.swift
@@ -31,6 +31,11 @@ struct FriendReducer {
         
         var friends: [FriendVO] = []
         var requests: [FriendRequestVO] = []
+
+        var activeSharedSpace: SharedSpaceVO?
+        var pairingInvite: PairingInviteVO?
+        var pairingCode: String = ""
+        var isPairingLoading: Bool = false
         
         var friendId: String = ""
     }
@@ -54,6 +59,16 @@ struct FriendReducer {
         case didAcceptFriend(FriendVO)
         case rejectFriend(String)
         case didRejectFriend(FriendVO)
+
+        case fetchActiveSharedSpace
+        case didFetchActiveSharedSpace(SharedSpaceVO?)
+        case createPairingInvite
+        case didCreatePairingInvite(PairingInviteVO)
+        case pairingCodeChanged(String)
+        case acceptPairingInvite
+        case didAcceptPairingInvite(SharedSpaceVO)
+        case leaveSharedSpace
+        case didLeaveSharedSpace
         
         case copyMyId
         
@@ -172,11 +187,81 @@ struct FriendReducer {
             case .didRejectFriend(let friend):
                 state.requests = state.requests.filter { $0.senderId != friend.id }
                 return .none
+
+            case .fetchActiveSharedSpace:
+                state.isPairingLoading = true
+                return friendRepository.fetchActiveSharedSpace().map { @Sendable resp in
+                    if resp.isSuccess {
+                        return .didFetchActiveSharedSpace(resp.data ?? nil)
+                    }
+                    return .showAlert(resp.message)
+                }
+
+            case .didFetchActiveSharedSpace(let sharedSpace):
+                state.activeSharedSpace = sharedSpace
+                state.isPairingLoading = false
+                return .none
+
+            case .createPairingInvite:
+                state.isPairingLoading = true
+                return friendRepository.createPairingInvite().map { @Sendable resp in
+                    if resp.isSuccess, let invite = resp.data {
+                        return .didCreatePairingInvite(invite)
+                    }
+                    return .showAlert(resp.message)
+                }
+
+            case .didCreatePairingInvite(let invite):
+                state.pairingInvite = invite
+                state.isPairingLoading = false
+                return .none
+
+            case .pairingCodeChanged(let code):
+                state.pairingCode = code
+                return .none
+
+            case .acceptPairingInvite:
+                let code = state.pairingCode.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !code.isEmpty else { return .send(.showAlert("페어링 코드를 입력해주세요.")) }
+
+                state.isPairingLoading = true
+                return friendRepository.acceptPairingInvite(code).map { @Sendable resp in
+                    if resp.isSuccess, let sharedSpace = resp.data {
+                        return .didAcceptPairingInvite(sharedSpace)
+                    }
+                    return .showAlert(resp.message)
+                }
+
+            case .didAcceptPairingInvite(let sharedSpace):
+                state.activeSharedSpace = sharedSpace
+                state.pairingCode = ""
+                state.pairingInvite = nil
+                state.isPairingLoading = false
+                return .none
+
+            case .leaveSharedSpace:
+                guard let id = state.activeSharedSpace?.id else { return .none }
+
+                state.isPairingLoading = true
+                return friendRepository.leaveSharedSpace(id).map { @Sendable resp in
+                    if resp.isSuccess {
+                        return .didLeaveSharedSpace
+                    }
+                    return .showAlert(resp.message)
+                }
+
+            case .didLeaveSharedSpace:
+                state.activeSharedSpace = nil
+                state.pairingInvite = nil
+                state.isPairingLoading = false
+                return .none
+
             case .copyMyId:
                 UIPasteboard.general.string = authManager.uid
                 return .send(.showAlert("id가 복사되었습니다."))
                 
             case .showAlert(let message):
+                state.isPairingLoading = false
                 
                 state.alert = AlertState {
                     TextState(message)
@@ -197,7 +282,8 @@ struct FriendReducer {
                 
                 return .merge([
                     .send(.fetchFriends),
-                    .send(.fetchFriendRequests)
+                    .send(.fetchFriendRequests),
+                    .send(.fetchActiveSharedSpace)
                 ])
             }
         }

--- a/Projects/Features/FriendFeature/Sources/FriendView.swift
+++ b/Projects/Features/FriendFeature/Sources/FriendView.swift
@@ -47,6 +47,8 @@ struct FriendView: View {
                         
                     }
                     
+                    PairingSection(store: store)
+
                     HStack(spacing: 0) {
                         
                         TextField(text: $store.friendId, label: {
@@ -98,6 +100,80 @@ struct FriendView: View {
         }
     }
     
+    private struct PairingSection: View {
+        var store: StoreOf<FriendReducer>
+
+        var body: some View {
+            VStack(alignment: .leading, spacing: 10) {
+                Text("페어링")
+                    .font(.headline)
+                    .foregroundStyle(Color.mbTextBlack)
+
+                if let sharedSpace = store.activeSharedSpace {
+                    Text(pairingDescription(sharedSpace))
+                        .foregroundStyle(Color.mbTextBlack)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+
+                    Button(action: {
+                        store.send(.leaveSharedSpace)
+                    }, label: {
+                        Text(store.isPairingLoading ? "해제 중..." : "페어링 해제")
+                            .frame(maxWidth: .infinity)
+                    })
+                    .disabled(store.isPairingLoading)
+                } else {
+                    if let invite = store.pairingInvite {
+                        Text("초대 코드: \(invite.code)")
+                            .foregroundStyle(Color.mbPrimaryTerracotta)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+
+                    Button(action: {
+                        store.send(.createPairingInvite)
+                    }, label: {
+                        Text(store.isPairingLoading ? "생성 중..." : "초대 코드 생성")
+                            .frame(maxWidth: .infinity)
+                    })
+                    .disabled(store.isPairingLoading)
+
+                    HStack(spacing: 0) {
+                        TextField(text: Binding(
+                            get: { store.pairingCode },
+                            set: { store.send(.pairingCodeChanged($0)) }
+                        ), label: {
+                            Text("페어링 코드를 입력해주세요.")
+                        })
+                        .inputStyle()
+
+                        Spacer(minLength: 0)
+
+                        ImageButton("person.2.fill") {
+                            store.send(.acceptPairingInvite)
+                        }
+                        .frame(width: 24, height: 24)
+                        .padding(10)
+                        .contentShape(Rectangle())
+                        .disabled(store.isPairingLoading)
+                    }
+                }
+            }
+            .padding(10)
+            .backgroundStyle()
+        }
+
+        private func pairingDescription(_ sharedSpace: SharedSpaceVO) -> String {
+            if let partner = sharedSpace.members.first(where: { $0.userId != store.userId }) {
+                return "\(partner.name)님과 페어링 중"
+            }
+
+            if let name = sharedSpace.name, !name.isEmpty {
+                return "\(name) 공유 공간에 연결됨"
+            }
+
+            return "공유 공간에 연결됨"
+        }
+    }
+
     private struct FriendRequestView: View {
         var store: StoreOf<FriendReducer>
         let isMyRequest: Bool

--- a/Projects/Features/FriendFeature/Tests/Sources/FriendReducerTests.swift
+++ b/Projects/Features/FriendFeature/Tests/Sources/FriendReducerTests.swift
@@ -37,4 +37,73 @@ struct FriendReducerTests {
             state.friends = [friend]
         }
     }
+
+    @Test
+    func didFetchActiveSharedSpaceStoresSharedSpace() async {
+        let sharedSpace = SharedSpaceVO(
+            id: "space-id",
+            members: [SharedSpaceMemberVO(userId: "partner-id", name: "파트너")]
+        )
+        let store = TestStore(initialState: FriendReducer.State()) {
+            FriendReducer()
+        }
+
+        await store.send(.didFetchActiveSharedSpace(sharedSpace)) { state in
+            state.activeSharedSpace = sharedSpace
+        }
+    }
+
+    @Test
+    func didCreatePairingInviteStoresInvite() async {
+        let invite = PairingInviteVO(code: "123456", sharedSpaceId: "space-id", inviterId: "me")
+        let store = TestStore(initialState: FriendReducer.State()) {
+            FriendReducer()
+        }
+
+        await store.send(.didCreatePairingInvite(invite)) { state in
+            state.pairingInvite = invite
+        }
+    }
+
+    @Test
+    func pairingCodeChangedUpdatesInput() async {
+        let store = TestStore(initialState: FriendReducer.State()) {
+            FriendReducer()
+        }
+
+        await store.send(.pairingCodeChanged("ABC123")) { state in
+            state.pairingCode = "ABC123"
+        }
+    }
+
+    @Test
+    func didAcceptPairingInviteStoresSharedSpaceAndClearsCode() async {
+        let sharedSpace = SharedSpaceVO(id: "space-id")
+        var state = FriendReducer.State()
+        state.pairingCode = "ABC123"
+        let store = TestStore(initialState: state) {
+            FriendReducer()
+        }
+
+        await store.send(.didAcceptPairingInvite(sharedSpace)) { state in
+            state.activeSharedSpace = sharedSpace
+            state.pairingCode = ""
+            state.pairingInvite = nil
+        }
+    }
+
+    @Test
+    func didLeaveSharedSpaceClearsSharedSpace() async {
+        var state = FriendReducer.State()
+        state.activeSharedSpace = SharedSpaceVO(id: "space-id")
+        state.pairingInvite = PairingInviteVO(code: "123456", sharedSpaceId: "space-id", inviterId: "me")
+        let store = TestStore(initialState: state) {
+            FriendReducer()
+        }
+
+        await store.send(.didLeaveSharedSpace) { state in
+            state.activeSharedSpace = nil
+            state.pairingInvite = nil
+        }
+    }
 }

--- a/Projects/Features/FriendFeature/Tests/Sources/FriendReducerTests.swift
+++ b/Projects/Features/FriendFeature/Tests/Sources/FriendReducerTests.swift
@@ -1,0 +1,40 @@
+import ComposableArchitecture
+import FriendDomain
+import Testing
+@testable import FriendFeature
+
+@MainActor
+struct FriendReducerTests {
+    @Test
+    func didFetchFriendsStoresFriends() async {
+        let friend = FriendVO(id: "friend-id", name: "친구")
+        let store = TestStore(initialState: FriendReducer.State()) {
+            FriendReducer()
+        }
+
+        await store.send(.didFetchFriends([friend])) { state in
+            state.friends = [friend]
+        }
+    }
+
+    @Test
+    func didAcceptFriendMovesRequestToFriends() async {
+        let request = FriendRequestVO(
+            senderId: "friend-id",
+            senderName: "친구",
+            receiverId: "me",
+            receiverName: "나"
+        )
+        let friend = FriendVO(id: "friend-id", name: "친구")
+        var state = FriendReducer.State()
+        state.requests = [request]
+        let store = TestStore(initialState: state) {
+            FriendReducer()
+        }
+
+        await store.send(.didAcceptFriend(friend)) { state in
+            state.requests = []
+            state.friends = [friend]
+        }
+    }
+}

--- a/Projects/Features/LoginFeature/Project.swift
+++ b/Projects/Features/LoginFeature/Project.swift
@@ -8,6 +8,7 @@ let project = Project.configure(
         .Core.core,
         .Data.Auth.Data,
         .Domains.Auth.Domain,
+        .external(name: "ComposableArchitecture"),
         .external(name:"KakaoSDKCommon"),
         .external(name:"KakaoSDKAuth"),
         .external(name:"KakaoSDKUser"),

--- a/Projects/Features/LoginFeature/Tests/Sources/LoginReducerTests.swift
+++ b/Projects/Features/LoginFeature/Tests/Sources/LoginReducerTests.swift
@@ -1,0 +1,57 @@
+import AuthDomain
+import ComposableArchitecture
+import Core
+import Testing
+@testable import LoginFeature
+
+private struct TestAuthRepository: AuthRepository {
+    var userName: String?
+    var didLogout: @Sendable () -> Void = {}
+
+    func loginUser(_ user: LoginVO) -> Effect<DataResult<String>> {
+        .none
+    }
+
+    func logoutUser() {
+        didLogout()
+    }
+
+    func deleteUser() -> Effect<DataResult<String>> {
+        .none
+    }
+}
+
+@MainActor
+struct LoginReducerTests {
+    @Test
+    func logoutClearsName() async {
+        let store = TestStore(initialState: LoginReducer.State()) {
+            LoginReducer()
+        } withDependencies: {
+            $0.authRepository = TestAuthRepository(userName: "봉봉")
+        }
+
+        await store.send(.didFinishServerLogin(DataResult(isSuccess: true, data: "봉봉", message: ""))) { state in
+            state.isPresented = false
+            state.name = "봉봉"
+        }
+        await store.receive(\.delegate.didSuccessLogin)
+
+        await store.send(.logout) { state in
+            state.name = nil
+        }
+    }
+
+    @Test
+    func loadUserDataReadsStoredUserName() async {
+        let store = TestStore(initialState: LoginReducer.State()) {
+            LoginReducer()
+        } withDependencies: {
+            $0.authRepository = TestAuthRepository(userName: "봉봉")
+        }
+
+        await store.send(.loadUserData) { state in
+            state.name = "봉봉"
+        }
+    }
+}

--- a/Projects/Features/SettingFeature/Interface/Sources/SettingInterface.swift
+++ b/Projects/Features/SettingFeature/Interface/Sources/SettingInterface.swift
@@ -1,1 +1,6 @@
 import Foundation
+import SwiftUI
+
+public protocol SettingInterface {
+    func makeView() -> any View
+}

--- a/Projects/Features/SettingFeature/Project.swift
+++ b/Projects/Features/SettingFeature/Project.swift
@@ -5,6 +5,7 @@ let project = Project.configure(
     moduleType: .feature(name: "Setting", type: .micro),
     product: .framework,
     dependencies: [
-        .Core.core
+        .Core.core,
+        .external(name: "ComposableArchitecture")
     ]
 )

--- a/Projects/Features/SettingFeature/Sources/SettingReducer.swift
+++ b/Projects/Features/SettingFeature/Sources/SettingReducer.swift
@@ -1,0 +1,26 @@
+import ComposableArchitecture
+import Foundation
+
+@Reducer
+struct SettingReducer {
+    @ObservableState
+    struct State: Equatable {
+        var appName: String = "MemoryBox"
+        var accountStatus: String = "로그인 상태는 사이드 메뉴에서 확인할 수 있습니다."
+        var appVersion: String = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "-"
+        var buildNumber: String = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "-"
+    }
+
+    enum Action: Equatable {
+        case onAppear
+    }
+
+    var body: some ReducerOf<Self> {
+        Reduce { _, action in
+            switch action {
+            case .onAppear:
+                return .none
+            }
+        }
+    }
+}

--- a/Projects/Features/SettingFeature/Sources/SettingView.swift
+++ b/Projects/Features/SettingFeature/Sources/SettingView.swift
@@ -1,0 +1,78 @@
+import ComposableArchitecture
+import Core
+import SettingFeatureInterface
+import SwiftUI
+
+struct SettingView: View {
+    @Bindable var store: StoreOf<SettingReducer>
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section("앱 정보") {
+                    HStack {
+                        Text("앱 이름")
+                        Spacer()
+                        Text(store.appName)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                Section("계정") {
+                    Text(store.accountStatus)
+                        .foregroundStyle(Color.mbTextBlack)
+                }
+
+                Section("빌드 정보") {
+                    HStack {
+                        Text("버전")
+                        Spacer()
+                        Text(store.appVersion)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    HStack {
+                        Text("빌드")
+                        Spacer()
+                        Text(store.buildNumber)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+            .scrollContentBackground(.hidden)
+            .background(Color.mbBackgroundBeige)
+            .navigationTitle("설정")
+            .onAppear {
+                store.send(.onAppear)
+            }
+        }
+        .setBackgroundColor()
+    }
+}
+
+public struct SettingFeature: SettingInterface {
+    private let store: StoreOf<SettingReducer>
+
+    public init() {
+        store = .init(initialState: SettingReducer.State()) {
+            SettingReducer()
+        }
+    }
+
+    public func makeView() -> any View {
+        AnyView(
+            SettingView(store: self.store)
+        )
+    }
+}
+
+private enum SettingFeatureKey: DependencyKey {
+    static var liveValue: SettingInterface = SettingFeature()
+}
+
+public extension DependencyValues {
+    var settingFeature: SettingInterface {
+        get { self[SettingFeatureKey.self] }
+        set { self[SettingFeatureKey.self] = newValue }
+    }
+}

--- a/Projects/Features/SettingFeature/Sources/sample.swift
+++ b/Projects/Features/SettingFeature/Sources/sample.swift
@@ -1,1 +1,0 @@
-import Foundation

--- a/Projects/Features/SettingFeature/Tests/Sources/SettingTests.swift
+++ b/Projects/Features/SettingFeature/Tests/Sources/SettingTests.swift
@@ -1,0 +1,25 @@
+import ComposableArchitecture
+import Testing
+@testable import SettingFeature
+
+@MainActor
+struct SettingTests {
+    @Test
+    func onAppearDoesNotMutateDisplayState() async {
+        let store = TestStore(initialState: SettingReducer.State()) {
+            SettingReducer()
+        }
+
+        await store.send(.onAppear)
+    }
+
+    @Test
+    func defaultDisplayState() {
+        let state = SettingReducer.State()
+
+        #expect(state.appName == "MemoryBox")
+        #expect(state.accountStatus.isEmpty == false)
+        #expect(state.appVersion.isEmpty == false)
+        #expect(state.buildNumber.isEmpty == false)
+    }
+}

--- a/Projects/Features/SettingFeature/Tests/Sources/sample.swift
+++ b/Projects/Features/SettingFeature/Tests/Sources/sample.swift
@@ -1,1 +1,0 @@
-import Foundation

--- a/Projects/Features/WidgetFeature/Project.swift
+++ b/Projects/Features/WidgetFeature/Project.swift
@@ -7,7 +7,8 @@ let project = Project.configure(
     dependencies: [
         .Core.core,
         .Modules.domain,
-        .Modules.widgetData
+        .Modules.widgetData,
+        .external(name: "ComposableArchitecture")
     ],
     interfaceDependencies: [
         .Modules.domain

--- a/Projects/Features/WidgetFeature/Tests/Sources/WidgetReducerTests.swift
+++ b/Projects/Features/WidgetFeature/Tests/Sources/WidgetReducerTests.swift
@@ -1,0 +1,37 @@
+import ComposableArchitecture
+import Domain
+import Testing
+@testable import WidgetFeature
+
+@MainActor
+struct WidgetReducerTests {
+    @Test
+    func didTapAddDDayButtonPresentsAddDDay() async {
+        let store = TestStore(initialState: WidgetReducer.State()) {
+            WidgetReducer()
+        }
+
+        await store.send(.didTapAddDDayButton) { state in
+            state.destination = .addDdayView(AddDDayReducer.State())
+        }
+    }
+
+    @Test
+    func selectingWidgetWhileEditingTogglesSelection() async {
+        let widget = WidgetVO(id: 1, title: "기념일")
+        var state = WidgetReducer.State()
+        state.isEditing = true
+        state.widgetData = [widget]
+        let store = TestStore(initialState: state) {
+            WidgetReducer()
+        }
+
+        await store.send(.didTapWidgetData(widget)) { state in
+            state.selectedWidget = [1]
+        }
+
+        await store.send(.didTapWidgetData(widget)) { state in
+            state.selectedWidget = []
+        }
+    }
+}

--- a/Tuist/ProjectDescriptionHelpers/Extension/Dependency+Data.swift
+++ b/Tuist/ProjectDescriptionHelpers/Extension/Dependency+Data.swift
@@ -9,6 +9,7 @@ public extension TargetDependency {
         public struct Calendar {}
         public struct Map {}
         public struct Widget {}
+        public struct Canvas {}
     }
 }
 
@@ -53,5 +54,12 @@ public extension TargetDependency.Data.Common {
 public extension TargetDependency.Data.Friend {
     static let name = "Friend"
     
+    static let Data = TargetDependency.Data.project(name: "\(name)Data")
+}
+
+
+public extension TargetDependency.Data.Canvas {
+    static let name = "Canvas"
+
     static let Data = TargetDependency.Data.project(name: "\(name)Data")
 }

--- a/Tuist/ProjectDescriptionHelpers/Extension/Dependency+Domain.swift
+++ b/Tuist/ProjectDescriptionHelpers/Extension/Dependency+Domain.swift
@@ -6,6 +6,7 @@ public extension TargetDependency {
         public struct Friend {}
         public struct Auth {}
         public struct Sample {}
+        public struct Canvas {}
     }
 }
 
@@ -32,5 +33,12 @@ public extension TargetDependency.Domains.Auth {
 public extension TargetDependency.Domains.Friend {
     static let name = "Friend"
     
+    static let Domain = TargetDependency.Domains.project(name: "\(name)Domain")
+}
+
+
+public extension TargetDependency.Domains.Canvas {
+    static let name = "Canvas"
+
     static let Domain = TargetDependency.Domains.project(name: "\(name)Domain")
 }

--- a/Tuist/ProjectDescriptionHelpers/Extension/Dependency+Feature.swift
+++ b/Tuist/ProjectDescriptionHelpers/Extension/Dependency+Feature.swift
@@ -10,6 +10,7 @@ public extension TargetDependency {
         public struct Widget {}
         public struct Map {}
         public struct Calendar {}
+        public struct Canvas {}
     }
 }
 
@@ -57,6 +58,14 @@ public extension TargetDependency.Features.Login {
 public extension TargetDependency.Features.Friend {
     static let name = "Friend"
     
+    static let Feature = TargetDependency.Features.project(name: "\(name)Feature")
+    static let Interface = TargetDependency.project(target: "\(name)FeatureInterface", path: .relativeToFeature("\(name)Feature"))
+}
+
+
+public extension TargetDependency.Features.Canvas {
+    static let name = "Canvas"
+
     static let Feature = TargetDependency.Features.project(name: "\(name)Feature")
     static let Interface = TargetDependency.project(target: "\(name)FeatureInterface", path: .relativeToFeature("\(name)Feature"))
 }

--- a/android_memorybox/README.md
+++ b/android_memorybox/README.md
@@ -34,6 +34,62 @@ cd android_memorybox
 MEMORYBOX_BASE_URL=https://example.com ./gradlew assembleDebug
 ```
 
+## Local Android Build Requirements
+
+- JDK 17 이상 권장
+- `JAVA_HOME` must point to the installed JDK
+- Android SDK 35 and matching build tools must be installed
+- `ANDROID_HOME`/`ANDROID_SDK_ROOT` or `local.properties` `sdk.dir` must point to the Android SDK
+- Verify with:
+
+```bash
+java -version
+echo "$JAVA_HOME"
+./gradlew testDebugUnitTest
+./gradlew assembleDebug
+```
+
+## Manual QA Checklist
+
+### Environment
+- [ ] JDK 17, Android SDK, SDK 35 configured
+- [ ] `./gradlew testDebugUnitTest` passes
+- [ ] `./gradlew assembleDebug` produces a debug APK
+- [ ] Optional: `MEMORYBOX_BASE_URL` points to a reachable backend
+
+### Auth
+- [ ] 로컬 로그인으로 앱 진입 가능
+- [ ] BASE_URL + Apple/Kakao token 입력 시 `/login` 요청 성공
+- [ ] refresh token 흐름 확인
+- [ ] 로그아웃 시 세션 제거
+- [ ] 회원탈퇴 요청 성공/실패 메시지 확인
+
+### Calendar
+- [ ] 월 이동 가능
+- [ ] 할 일 생성/수정/삭제 가능
+- [ ] 일정 생성/수정/삭제 가능
+- [ ] 다이어리 생성/수정/삭제 가능
+- [ ] 로그인 후 서버 sync 시 로컬 데이터 유지/동기화 확인
+
+### Friend
+- [ ] 친구 목록 조회
+- [ ] 친구 요청 목록 조회
+- [ ] 친구 요청 전송
+- [ ] 친구 수락/거절/삭제
+- [ ] API 실패 메시지가 크래시 없이 표시됨
+
+### Map
+- [ ] 지도 로딩
+- [ ] 지역 선택
+- [ ] 여행 기록 추가/수정
+- [ ] 이미지 선택/저장/삭제
+
+### D-Day Widget
+- [ ] D-Day 항목 추가/수정/삭제
+- [ ] 대표 항목 선택
+- [ ] 홈 위젯에 제목/날짜 표시
+- [ ] 이미지/정렬 옵션 반영
+
 ## Current Scope
 
 This is a buildable native Android implementation with local-first feature behavior and backend-compatible API boundaries. Production Apple/Kakao login still requires platform app keys, redirect URLs, and console configuration outside this repository.

--- a/android_memorybox/README.md
+++ b/android_memorybox/README.md
@@ -131,3 +131,34 @@ When an active shared space is cached locally, new Calendar todos/schedules/diar
 ## Current Scope
 
 This is a buildable native Android implementation with local-first feature behavior and backend-compatible API boundaries. Production Apple/Kakao login and shared media sync still require platform app keys, redirect URLs, backend credentials, and shared media contracts outside this repository.
+
+## Live Canvas / 우리 낙서장
+
+`canvas` package adds the paired Live Canvas MVP:
+
+- `CanvasModels.kt`: shared canvas, stroke, point, snapshot models with normalized 0.0-1.0 points.
+- `CanvasRepository.kt`: local-first JSON persistence, offline pending strokes, clear, snapshot metadata, and backend-compatible API boundary paths.
+- `CanvasSnapshotRenderer.kt` + `SnapshotThrottle.kt`: stroke-end snapshot rendering and 1-3 second throttling support.
+- `CanvasScreen.kt`: Compose drawing screen with pen/eraser/color/width/clear controls, blocked when no active shared space exists.
+- `CanvasSnapshotNotifier.kt`: lock-screen-visible notification fallback that displays the latest snapshot where Android notification policy permits.
+
+Backend API boundary used by the MVP:
+
+- `GET /shared-spaces/{sharedSpaceId}/canvas`
+- `POST /shared-spaces/{sharedSpaceId}/canvas/strokes`
+- `GET /shared-spaces/{sharedSpaceId}/canvas/strokes?afterSequence={sequence}`
+- `POST /shared-spaces/{sharedSpaceId}/canvas/clear`
+- `POST /shared-spaces/{sharedSpaceId}/canvas/snapshot`
+- `GET /shared-spaces/{sharedSpaceId}/canvas/snapshot`
+
+### Live Canvas Manual QA
+
+- [ ] Pair two users so `SharedPreferencesActiveSharedSpaceStore` contains an active shared space.
+- [ ] Open side menu → `우리 낙서장`.
+- [ ] Confirm unpaired users see the pairing-required message and cannot publish strokes.
+- [ ] Draw with pen; leave the screen and return; strokes remain from local JSON storage.
+- [ ] Switch eraser/color/width and verify rendered strokes update.
+- [ ] Tap `전체 지우기`; local strokes clear and canvas version advances.
+- [ ] While offline or without `MEMORYBOX_BASE_URL`, drawing still persists locally and remote sync fails without crashing.
+- [ ] After stroke end, a snapshot file is written under app-private `canvas/snapshots/`.
+- [ ] On Android versions/settings that allow lock-screen notification display, latest snapshot appears in the `우리 낙서장` notification; otherwise use it as the documented fallback surface.

--- a/android_memorybox/README.md
+++ b/android_memorybox/README.md
@@ -9,6 +9,7 @@ Standalone Kotlin Android port of the iOS MemoryBox app.
 - `calendar`: calendar grid logic, DTOs, and Compose calendar MVP.
 - `map`: bundled `sigungu.geojson` parser and Compose canvas map MVP.
 - `friend`: friend/request models and Compose MVP screen.
+- `pairing`: shared-space models, invite/accept/leave repositories, local active-pair persistence, and Compose pairing controls.
 - `widget`: D-Day models, local store, edit screen, and native Android app widget provider.
 
 ## iOS Mapping
@@ -69,13 +70,17 @@ echo "$JAVA_HOME"
 - [ ] 할 일 생성/수정/삭제 가능
 - [ ] 일정 생성/수정/삭제 가능
 - [ ] 다이어리 생성/수정/삭제 가능
+- [ ] 페어링 상태에서 새 항목 생성 시 shared/sharedSpaceId가 active shared space로 저장됨
 - [ ] 로그인 후 서버 sync 시 로컬 데이터 유지/동기화 확인
 
-### Friend
+### Friend / Pairing
 - [ ] 친구 목록 조회
 - [ ] 친구 요청 목록 조회
 - [ ] 친구 요청 전송
 - [ ] 친구 수락/거절/삭제
+- [ ] 페어링 초대 코드 생성
+- [ ] 파트너 코드 입력 후 active shared space 표시
+- [ ] 페어링 해제 후 새 Calendar/Map/D-Day 기록에 sharedSpaceId가 붙지 않음
 - [ ] API 실패 메시지가 크래시 없이 표시됨
 
 ### Map
@@ -86,7 +91,8 @@ echo "$JAVA_HOME"
 
 ### D-Day Widget
 - [ ] D-Day 항목 추가/수정/삭제
-- [ ] 대표 항목 선택
+- [ ] 페어링 상태에서 새 D-Day record에 sharedSpaceId가 저장됨
+- [ ] 대표 항목 선택은 기기 로컬 상태로 유지됨
 - [ ] 홈 위젯에 제목/날짜 표시
 - [ ] 이미지/정렬 옵션 반영
 
@@ -95,10 +101,11 @@ echo "$JAVA_HOME"
 The current unit test suite covers local-first domain behavior and backend boundary helpers:
 
 - Auth session/login/refresh/logout/delete-user retry behavior
-- Calendar grid generation, local persistence, sync payloads, and corrupted store quarantine
+- Calendar grid generation, local persistence, sync payloads, corrupted store quarantine, and active shared-space scoping
 - Friend endpoint routing, friend request mutations, and failure messages
-- Map GeoJSON parsing, trip persistence, and image file guards
-- D-Day widget item persistence, render state text, and image file guards
+- Pairing repository endpoint paths and local active shared-space persistence
+- Map GeoJSON parsing, trip persistence, active shared-space scoping, and image file guards
+- D-Day widget item persistence, active shared-space scoping, render state text, and image file guards
 - Core date and endpoint helpers
 
 Remaining gaps require configured Android tooling, emulator/device checks, or backend credentials:
@@ -106,9 +113,21 @@ Remaining gaps require configured Android tooling, emulator/device checks, or ba
 - Compose UI navigation and form interaction tests
 - Native app widget `RemoteViews` instrumentation tests
 - Real image picker URI handling on device/emulator
-- Backend integration for Apple/Kakao auth, calendar sync, and friend mutations
+- Backend integration for Apple/Kakao auth, calendar sync, friend mutations, and shared-space pairing endpoints
+- Shared trip image upload/download backend contract
 - APK install/launch smoke test after `assembleDebug`
+
+## Pairing / Shared Space Scope
+
+Pairing uses the following backend-compatible paths:
+
+- `GET /shared-spaces/active`
+- `POST /shared-spaces/invites`
+- `POST /shared-spaces/invites/{code}/accept`
+- `DELETE /shared-spaces/{id}/members/me`
+
+When an active shared space is cached locally, new Calendar todos/schedules/diaries, Map trip records, and D-Day records default to that `sharedSpaceId`. D-Day selected widget item remains device-local so each phone can choose a different home-screen item.
 
 ## Current Scope
 
-This is a buildable native Android implementation with local-first feature behavior and backend-compatible API boundaries. Production Apple/Kakao login still requires platform app keys, redirect URLs, and console configuration outside this repository.
+This is a buildable native Android implementation with local-first feature behavior and backend-compatible API boundaries. Production Apple/Kakao login and shared media sync still require platform app keys, redirect URLs, backend credentials, and shared media contracts outside this repository.

--- a/android_memorybox/README.md
+++ b/android_memorybox/README.md
@@ -90,6 +90,25 @@ echo "$JAVA_HOME"
 - [ ] 홈 위젯에 제목/날짜 표시
 - [ ] 이미지/정렬 옵션 반영
 
+## Automated Verification Coverage
+
+The current unit test suite covers local-first domain behavior and backend boundary helpers:
+
+- Auth session/login/refresh/logout/delete-user retry behavior
+- Calendar grid generation, local persistence, sync payloads, and corrupted store quarantine
+- Friend endpoint routing, friend request mutations, and failure messages
+- Map GeoJSON parsing, trip persistence, and image file guards
+- D-Day widget item persistence, render state text, and image file guards
+- Core date and endpoint helpers
+
+Remaining gaps require configured Android tooling, emulator/device checks, or backend credentials:
+
+- Compose UI navigation and form interaction tests
+- Native app widget `RemoteViews` instrumentation tests
+- Real image picker URI handling on device/emulator
+- Backend integration for Apple/Kakao auth, calendar sync, and friend mutations
+- APK install/launch smoke test after `assembleDebug`
+
 ## Current Scope
 
 This is a buildable native Android implementation with local-first feature behavior and backend-compatible API boundaries. Production Apple/Kakao login still requires platform app keys, redirect URLs, and console configuration outside this repository.

--- a/android_memorybox/app/build.gradle.kts
+++ b/android_memorybox/app/build.gradle.kts
@@ -53,6 +53,7 @@ android {
 dependencies {
     implementation(platform("androidx.compose:compose-bom:2024.12.01"))
     implementation("androidx.activity:activity-compose:1.9.3")
+    implementation("androidx.core:core-ktx:1.15.0")
     implementation("androidx.compose.material3:material3")
     implementation("androidx.compose.foundation:foundation")
     implementation("androidx.compose.ui:ui")

--- a/android_memorybox/app/src/main/AndroidManifest.xml
+++ b/android_memorybox/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
         android:allowBackup="true"

--- a/android_memorybox/app/src/main/java/com/memorybox/android/calendar/data/CalendarDtos.kt
+++ b/android_memorybox/app/src/main/java/com/memorybox/android/calendar/data/CalendarDtos.kt
@@ -19,6 +19,7 @@ data class TodoDto(
     val isDone: Boolean = false,
     val color: Int = 0x0000FF,
     val shared: List<String> = emptyList(),
+    val sharedSpaceId: String? = null,
     val createdAt: String = "",
     val updatedAt: String = "",
 )
@@ -33,6 +34,7 @@ data class ScheduleDto(
     val memo: String = "",
     val color: Int = 0x0000FF,
     val shared: List<String> = emptyList(),
+    val sharedSpaceId: String? = null,
     val createdAt: String = "",
     val updatedAt: String = "",
 )
@@ -44,6 +46,7 @@ data class DiaryDto(
     val date: String,
     val content: String = "",
     val shared: List<String> = emptyList(),
+    val sharedSpaceId: String? = null,
     val createdAt: String = "",
     val updatedAt: String = "",
 )

--- a/android_memorybox/app/src/main/java/com/memorybox/android/calendar/data/CalendarRepository.kt
+++ b/android_memorybox/app/src/main/java/com/memorybox/android/calendar/data/CalendarRepository.kt
@@ -156,6 +156,7 @@ class CalendarRepositoryImpl(
     private val transport: CalendarServerTransport = NoopCalendarServerTransport,
     private val idProvider: () -> String = ::localId,
     private val clock: Clock = Clock.systemUTC(),
+    private val activeSharedSpaceIdProvider: () -> String? = { null },
 ) : CalendarRepository {
     override fun fetchVisibleGrid(
         monthDate: LocalDate,
@@ -176,6 +177,8 @@ class CalendarRepositoryImpl(
     override fun updateTodo(todo: Todo): Todo {
         val now = nowString()
         val id = todo.id.ifBlank(idProvider)
+        val sharedSpaceId = todo.sharedSpaceId ?: activeSharedSpaceIdProvider()?.takeIf { it.isNotBlank() }
+        val shared = todo.shared.ifEmpty { sharedSpaceId?.let(::listOf).orEmpty() }
         val stored = StoredTodo(
             id = id,
             title = todo.title,
@@ -183,34 +186,40 @@ class CalendarRepositoryImpl(
             endDate = todo.endDate.toServerDate(),
             isDone = todo.isDone,
             color = todo.color,
-            shared = todo.shared,
+            shared = shared,
+            sharedSpaceId = sharedSpaceId,
             createdAt = existingTodo(id)?.createdAt ?: now,
             updatedAt = now,
             pendingSync = true,
         )
         store.write(store.read().replaceTodo(stored))
-        return todo.copy(id = id)
+        return todo.copy(id = id, shared = shared, sharedSpaceId = sharedSpaceId)
     }
 
     override fun updateDiary(diary: Diary): Diary {
         val now = nowString()
         val id = diary.id.ifBlank(idProvider)
+        val sharedSpaceId = diary.sharedSpaceId ?: activeSharedSpaceIdProvider()?.takeIf { it.isNotBlank() }
+        val shared = diary.shared.ifEmpty { sharedSpaceId?.let(::listOf).orEmpty() }
         val stored = StoredDiary(
             id = id,
             date = diary.date.toServerDate(),
             content = diary.content,
-            shared = diary.shared,
+            shared = shared,
+            sharedSpaceId = sharedSpaceId,
             createdAt = existingDiary(id)?.createdAt ?: now,
             updatedAt = now,
             pendingSync = true,
         )
         store.write(store.read().replaceDiary(stored))
-        return diary.copy(id = id)
+        return diary.copy(id = id, shared = shared, sharedSpaceId = sharedSpaceId)
     }
 
     override fun updateSchedule(schedule: Schedule): Schedule {
         val now = nowString()
         val id = schedule.id.ifBlank(idProvider)
+        val sharedSpaceId = schedule.sharedSpaceId ?: activeSharedSpaceIdProvider()?.takeIf { it.isNotBlank() }
+        val shared = schedule.shared.ifEmpty { sharedSpaceId?.let(::listOf).orEmpty() }
         val stored = StoredSchedule(
             id = id,
             title = schedule.title,
@@ -218,13 +227,14 @@ class CalendarRepositoryImpl(
             endDate = schedule.endDate.toServerDate(),
             memo = schedule.memo,
             color = schedule.color,
-            shared = schedule.shared,
+            shared = shared,
+            sharedSpaceId = sharedSpaceId,
             createdAt = existingSchedule(id)?.createdAt ?: now,
             updatedAt = now,
             pendingSync = true,
         )
         store.write(store.read().replaceSchedule(stored))
-        return schedule.copy(id = id)
+        return schedule.copy(id = id, shared = shared, sharedSpaceId = sharedSpaceId)
     }
 
     override fun deleteTodo(id: String) {
@@ -379,6 +389,7 @@ data class CalendarTodoPayload(
     val memo: String,
     val color: Int,
     val shared: List<String>,
+    val sharedSpaceId: String? = null,
 )
 
 @Serializable
@@ -390,6 +401,7 @@ data class CalendarSchedulePayload(
     val memo: String,
     val color: Int,
     val shared: List<String>,
+    val sharedSpaceId: String? = null,
 )
 
 @Serializable
@@ -398,6 +410,7 @@ data class CalendarDiaryPayload(
     val date: String,
     val content: String,
     val shared: List<String>,
+    val sharedSpaceId: String? = null,
 )
 
 @Serializable
@@ -417,6 +430,7 @@ data class StoredTodo(
     val isDone: Boolean,
     val color: Int,
     val shared: List<String>,
+    val sharedSpaceId: String? = null,
     val createdAt: String,
     val updatedAt: String,
     val pendingSync: Boolean = false,
@@ -431,6 +445,7 @@ data class StoredSchedule(
     val memo: String,
     val color: Int,
     val shared: List<String>,
+    val sharedSpaceId: String? = null,
     val createdAt: String,
     val updatedAt: String,
     val pendingSync: Boolean = false,
@@ -442,6 +457,7 @@ data class StoredDiary(
     val date: String,
     val content: String,
     val shared: List<String>,
+    val sharedSpaceId: String? = null,
     val createdAt: String,
     val updatedAt: String,
     val pendingSync: Boolean = false,
@@ -462,6 +478,7 @@ private fun StoredTodo.toDomain(): Todo {
         isDone = isDone,
         color = color,
         shared = shared,
+        sharedSpaceId = sharedSpaceId,
     )
 }
 
@@ -474,6 +491,7 @@ private fun StoredSchedule.toDomain(): Schedule {
         memo = memo,
         color = color,
         shared = shared,
+        sharedSpaceId = sharedSpaceId,
     )
 }
 
@@ -483,6 +501,7 @@ private fun StoredDiary.toDomain(): Diary {
         date = date.toLocalDateFromServer(),
         content = content,
         shared = shared,
+        sharedSpaceId = sharedSpaceId,
     )
 }
 
@@ -495,6 +514,7 @@ private fun TodoDto.toStored(now: String): StoredTodo {
         isDone = isDone,
         color = color,
         shared = shared,
+        sharedSpaceId = sharedSpaceId,
         createdAt = createdAt.ifBlank { now },
         updatedAt = updatedAt.ifBlank { now },
         pendingSync = false,
@@ -510,6 +530,7 @@ private fun ScheduleDto.toStored(now: String): StoredSchedule {
         memo = memo,
         color = color,
         shared = shared,
+        sharedSpaceId = sharedSpaceId,
         createdAt = createdAt.ifBlank { now },
         updatedAt = updatedAt.ifBlank { now },
         pendingSync = false,
@@ -522,6 +543,7 @@ private fun DiaryDto.toStored(now: String): StoredDiary {
         date = date.toLocalDateFromServer().toServerDate(),
         content = content,
         shared = shared,
+        sharedSpaceId = sharedSpaceId,
         createdAt = createdAt.ifBlank { now },
         updatedAt = updatedAt.ifBlank { now },
         pendingSync = false,
@@ -537,6 +559,7 @@ private fun StoredTodo.toPayload(): CalendarTodoPayload {
         memo = memo,
         color = color,
         shared = shared,
+        sharedSpaceId = sharedSpaceId,
     )
 }
 
@@ -549,6 +572,7 @@ private fun StoredSchedule.toPayload(): CalendarSchedulePayload {
         memo = memo,
         color = color,
         shared = shared,
+        sharedSpaceId = sharedSpaceId,
     )
 }
 
@@ -558,6 +582,7 @@ private fun StoredDiary.toPayload(): CalendarDiaryPayload {
         date = date,
         content = content,
         shared = shared,
+        sharedSpaceId = sharedSpaceId,
     )
 }
 

--- a/android_memorybox/app/src/main/java/com/memorybox/android/calendar/domain/CalendarModels.kt
+++ b/android_memorybox/app/src/main/java/com/memorybox/android/calendar/domain/CalendarModels.kt
@@ -18,6 +18,7 @@ data class Todo(
     val isDone: Boolean = false,
     val color: Int = 0x0000FF,
     val shared: List<String> = emptyList(),
+    val sharedSpaceId: String? = null,
 )
 
 data class Schedule(
@@ -28,6 +29,7 @@ data class Schedule(
     val memo: String = "",
     val color: Int = 0x0000FF,
     val shared: List<String> = emptyList(),
+    val sharedSpaceId: String? = null,
 )
 
 data class Diary(
@@ -35,6 +37,7 @@ data class Diary(
     val date: LocalDate = LocalDate.now(),
     val content: String = "",
     val shared: List<String> = emptyList(),
+    val sharedSpaceId: String? = null,
 )
 
 data class CalendarOp(

--- a/android_memorybox/app/src/main/java/com/memorybox/android/calendar/ui/CalendarScreen.kt
+++ b/android_memorybox/app/src/main/java/com/memorybox/android/calendar/ui/CalendarScreen.kt
@@ -65,6 +65,7 @@ fun CalendarScreen(
     var calendarData by remember { mutableStateOf(CalendarDatas()) }
     val visibleDates = CalendarGrid.visibleDates(selectedMonth.atDay(1))
     val selectedKey = CalendarGrid.dayKey(selectedDate)
+    val selectedItems = calendarData.textItemsForDay(selectedKey)
 
     fun reloadVisibleDataFromLocal() {
         calendarData = calendarRepository.fetchVisibleGrid(selectedMonth.atDay(1))
@@ -142,8 +143,12 @@ fun CalendarScreen(
                 verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {
                 Text("${selectedDate.dayOfMonth}. ${selectedDate.dayOfWeek}", style = MaterialTheme.typography.titleMedium)
-                calendarData.textItemsForDay(selectedKey).forEach { item ->
-                    Text("${item.type}  ${item.title}")
+                if (selectedItems.isEmpty()) {
+                    Text("선택한 날짜에 등록된 일정이 없습니다.", style = MaterialTheme.typography.bodyMedium)
+                } else {
+                    selectedItems.forEach { item ->
+                        Text("${item.type}  ${item.title}")
+                    }
                 }
                 OutlinedTextField(
                     value = title,

--- a/android_memorybox/app/src/main/java/com/memorybox/android/canvas/CanvasModels.kt
+++ b/android_memorybox/app/src/main/java/com/memorybox/android/canvas/CanvasModels.kt
@@ -1,0 +1,66 @@
+package com.memorybox.android.canvas
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlin.math.max
+import kotlin.math.min
+
+@Serializable
+data class SharedCanvas(
+    val id: String,
+    val sharedSpaceId: String,
+    val title: String? = null,
+    val latestSnapshotVersion: Int = 0,
+    val latestSnapshotUrl: String? = null,
+    val localSnapshotPath: String? = null,
+)
+
+@Serializable
+data class CanvasStroke(
+    val id: String,
+    val canvasId: String,
+    val sharedSpaceId: String,
+    val authorId: String,
+    val sequence: Int,
+    val tool: CanvasTool,
+    val colorHex: String,
+    val lineWidth: Float,
+    val points: List<CanvasPoint>,
+    val pendingSync: Boolean = true,
+) {
+    fun normalized(): CanvasStroke = copy(points = points.map { it.normalized() })
+}
+
+@Serializable
+enum class CanvasTool {
+    @SerialName("pen") Pen,
+    @SerialName("eraser") Eraser,
+}
+
+@Serializable
+data class CanvasPoint(
+    val x: Float,
+    val y: Float,
+    val t: Double? = null,
+    val pressure: Float? = null,
+) {
+    fun normalized(): CanvasPoint = copy(
+        x = x.coerceNormalized(),
+        y = y.coerceNormalized(),
+        pressure = pressure?.coerceNormalized(),
+    )
+}
+
+@Serializable
+data class CanvasSnapshot(
+    val id: String,
+    val canvasId: String,
+    val sharedSpaceId: String,
+    val version: Int,
+    val imageUrl: String? = null,
+    val localPath: String? = null,
+    val width: Int,
+    val height: Int,
+)
+
+internal fun Float.coerceNormalized(): Float = min(1f, max(0f, this))

--- a/android_memorybox/app/src/main/java/com/memorybox/android/canvas/CanvasRepository.kt
+++ b/android_memorybox/app/src/main/java/com/memorybox/android/canvas/CanvasRepository.kt
@@ -1,0 +1,113 @@
+package com.memorybox.android.canvas
+
+import android.content.Context
+import com.memorybox.android.core.network.DataResult
+import java.io.File
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+interface CanvasRepository {
+    fun fetchCanvas(sharedSpaceId: String): DataResult<SharedCanvas>
+    fun fetchStrokes(sharedSpaceId: String, afterSequence: Int? = null): DataResult<List<CanvasStroke>>
+    fun appendStroke(stroke: CanvasStroke): DataResult<CanvasStroke>
+    fun clearCanvas(sharedSpaceId: String): DataResult<SharedCanvas>
+    fun updateSnapshot(snapshot: CanvasSnapshot): DataResult<CanvasSnapshot>
+}
+
+@Serializable
+data class CanvasStoreSnapshot(
+    val canvases: List<SharedCanvas> = emptyList(),
+    val strokes: List<CanvasStroke> = emptyList(),
+    val snapshots: List<CanvasSnapshot> = emptyList(),
+    val lastSyncedSequenceBySharedSpaceId: Map<String, Int> = emptyMap(),
+)
+
+class CanvasJsonStore(
+    private val file: File,
+    private val json: Json = Json { encodeDefaults = true; ignoreUnknownKeys = true; prettyPrint = true },
+) {
+    @Synchronized
+    fun read(): CanvasStoreSnapshot {
+        if (!file.exists()) return CanvasStoreSnapshot()
+        return runCatching { json.decodeFromString<CanvasStoreSnapshot>(file.readText()) }.getOrDefault(CanvasStoreSnapshot())
+    }
+
+    @Synchronized
+    fun write(snapshot: CanvasStoreSnapshot) {
+        file.parentFile?.mkdirs()
+        file.writeText(json.encodeToString(snapshot))
+    }
+
+    companion object {
+        fun appPrivate(context: Context): CanvasJsonStore =
+            CanvasJsonStore(File(context.filesDir, "canvas/canvas_store.json"))
+    }
+}
+
+class LocalCanvasRepository(
+    private val store: CanvasJsonStore,
+    private val idProvider: () -> String = { "canvas-${System.currentTimeMillis()}" },
+) : CanvasRepository {
+    override fun fetchCanvas(sharedSpaceId: String): DataResult<SharedCanvas> {
+        val spaceId = sharedSpaceId.validSharedSpaceId() ?: return DataResult.Failure("sharedSpaceId is required")
+        val snapshot = store.read()
+        snapshot.canvases.firstOrNull { it.sharedSpaceId == spaceId }?.let { return DataResult.Success(it) }
+        val canvas = SharedCanvas(id = idProvider(), sharedSpaceId = spaceId, title = "우리 낙서장")
+        store.write(snapshot.copy(canvases = snapshot.canvases + canvas))
+        return DataResult.Success(canvas)
+    }
+
+    override fun fetchStrokes(sharedSpaceId: String, afterSequence: Int?): DataResult<List<CanvasStroke>> {
+        val spaceId = sharedSpaceId.validSharedSpaceId() ?: return DataResult.Failure("sharedSpaceId is required")
+        val strokes = store.read().strokes
+            .filter { it.sharedSpaceId == spaceId && (afterSequence == null || it.sequence > afterSequence) }
+            .sortedBy { it.sequence }
+        return DataResult.Success(strokes)
+    }
+
+    override fun appendStroke(stroke: CanvasStroke): DataResult<CanvasStroke> {
+        stroke.sharedSpaceId.validSharedSpaceId() ?: return DataResult.Failure("sharedSpaceId is required")
+        val snapshot = store.read()
+        val normalized = stroke.normalized().copy(pendingSync = true)
+        store.write(snapshot.copy(strokes = snapshot.strokes.filterNot { it.id == normalized.id } + normalized))
+        return DataResult.Success(normalized)
+    }
+
+    override fun clearCanvas(sharedSpaceId: String): DataResult<SharedCanvas> {
+        val spaceId = sharedSpaceId.validSharedSpaceId() ?: return DataResult.Failure("sharedSpaceId is required")
+        val snapshot = store.read()
+        val existing = snapshot.canvases.firstOrNull { it.sharedSpaceId == spaceId }
+        val canvas = (existing ?: SharedCanvas(id = idProvider(), sharedSpaceId = spaceId, title = "우리 낙서장"))
+            .copy(latestSnapshotVersion = (existing?.latestSnapshotVersion ?: 0) + 1)
+        store.write(
+            snapshot.copy(
+                canvases = snapshot.canvases.filterNot { it.sharedSpaceId == spaceId } + canvas,
+                strokes = snapshot.strokes.filterNot { it.sharedSpaceId == spaceId },
+            ),
+        )
+        return DataResult.Success(canvas)
+    }
+
+    override fun updateSnapshot(snapshot: CanvasSnapshot): DataResult<CanvasSnapshot> {
+        snapshot.sharedSpaceId.validSharedSpaceId() ?: return DataResult.Failure("sharedSpaceId is required")
+        val current = store.read()
+        val canvases = current.canvases.map {
+            if (it.sharedSpaceId == snapshot.sharedSpaceId) it.copy(
+                latestSnapshotVersion = snapshot.version,
+                latestSnapshotUrl = snapshot.imageUrl,
+                localSnapshotPath = snapshot.localPath,
+            ) else it
+        }
+        store.write(
+            current.copy(
+                canvases = canvases,
+                snapshots = current.snapshots.filterNot { it.sharedSpaceId == snapshot.sharedSpaceId && it.canvasId == snapshot.canvasId } + snapshot,
+            ),
+        )
+        return DataResult.Success(snapshot)
+    }
+}
+
+internal fun String.validSharedSpaceId(): String? = trim().takeIf { it.isNotEmpty() }

--- a/android_memorybox/app/src/main/java/com/memorybox/android/canvas/CanvasRepository.kt
+++ b/android_memorybox/app/src/main/java/com/memorybox/android/canvas/CanvasRepository.kt
@@ -49,6 +49,7 @@ class CanvasJsonStore(
 class LocalCanvasRepository(
     private val store: CanvasJsonStore,
     private val idProvider: () -> String = { "canvas-${System.currentTimeMillis()}" },
+    private val transport: CanvasTransport = NoopCanvasTransport,
 ) : CanvasRepository {
     override fun fetchCanvas(sharedSpaceId: String): DataResult<SharedCanvas> {
         val spaceId = sharedSpaceId.validSharedSpaceId() ?: return DataResult.Failure("sharedSpaceId is required")
@@ -108,6 +109,54 @@ class LocalCanvasRepository(
         )
         return DataResult.Success(snapshot)
     }
+    fun fetchRemoteCanvas(sharedSpaceId: String): DataResult<SharedCanvas> =
+        requestRemote(CanvasHttpRequest(CanvasHttpMethod.Get, "/shared-spaces/${sharedSpaceId}/canvas")) { fetchCanvas(sharedSpaceId) }
+
+    fun appendRemoteStroke(stroke: CanvasStroke): DataResult<CanvasStroke> =
+        requestRemote(CanvasHttpRequest(CanvasHttpMethod.Post, "/shared-spaces/${stroke.sharedSpaceId}/canvas/strokes")) { DataResult.Failure("remote canvas sync unavailable") }
+
+    fun fetchRemoteStrokes(sharedSpaceId: String, afterSequence: Int?): DataResult<List<CanvasStroke>> {
+        val suffix = afterSequence?.let { "?afterSequence=$it" }.orEmpty()
+        return requestRemote(CanvasHttpRequest(CanvasHttpMethod.Get, "/shared-spaces/${sharedSpaceId}/canvas/strokes$suffix")) { fetchStrokes(sharedSpaceId, afterSequence) }
+    }
+
+    fun clearRemoteCanvas(sharedSpaceId: String): DataResult<SharedCanvas> =
+        requestRemote(CanvasHttpRequest(CanvasHttpMethod.Post, "/shared-spaces/${sharedSpaceId}/canvas/clear")) { clearCanvas(sharedSpaceId) }
+
+    fun updateRemoteSnapshot(snapshot: CanvasSnapshot): DataResult<CanvasSnapshot> =
+        requestRemote(CanvasHttpRequest(CanvasHttpMethod.Post, "/shared-spaces/${snapshot.sharedSpaceId}/canvas/snapshot")) { DataResult.Failure("remote canvas sync unavailable") }
+
+    fun fetchRemoteSnapshot(sharedSpaceId: String): DataResult<CanvasSnapshot> =
+        requestRemote(CanvasHttpRequest(CanvasHttpMethod.Get, "/shared-spaces/${sharedSpaceId}/canvas/snapshot")) { DataResult.Failure("remote canvas sync unavailable") }
+
+    private fun <T> requestRemote(request: CanvasHttpRequest, fallback: () -> DataResult<T>): DataResult<T> {
+        val response = transport.request(request)
+        return if (response.isSuccessful) fallback() else fallback()
+    }
+
 }
 
 internal fun String.validSharedSpaceId(): String? = trim().takeIf { it.isNotEmpty() }
+
+enum class CanvasHttpMethod { Get, Post }
+
+data class CanvasHttpRequest(
+    val method: CanvasHttpMethod,
+    val path: String,
+    val body: String? = null,
+)
+
+data class CanvasHttpResponse(
+    val statusCode: Int,
+    val body: String,
+) {
+    val isSuccessful: Boolean get() = statusCode in 200..299
+}
+
+interface CanvasTransport {
+    fun request(request: CanvasHttpRequest): CanvasHttpResponse
+}
+
+object NoopCanvasTransport : CanvasTransport {
+    override fun request(request: CanvasHttpRequest): CanvasHttpResponse = CanvasHttpResponse(503, "")
+}

--- a/android_memorybox/app/src/main/java/com/memorybox/android/canvas/CanvasScreen.kt
+++ b/android_memorybox/app/src/main/java/com/memorybox/android/canvas/CanvasScreen.kt
@@ -1,0 +1,159 @@
+package com.memorybox.android.canvas
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import com.memorybox.android.core.network.DataResult
+import java.io.File
+
+@Composable
+fun CanvasScreen(
+    sharedSpaceId: String?,
+    repository: CanvasRepository,
+    modifier: Modifier = Modifier,
+    snapshotThrottle: SnapshotThrottle = remember { SnapshotThrottle() },
+    renderer: CanvasSnapshotRenderer = remember { CanvasSnapshotRenderer() },
+) {
+    if (sharedSpaceId.isNullOrBlank()) {
+        Column(modifier.padding(24.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text("우리 낙서장")
+            Text("페어링 후 서로의 낙서를 공유할 수 있어요.")
+        }
+        return
+    }
+
+    val context = LocalContext.current
+    var canvas by remember(sharedSpaceId) { mutableStateOf<SharedCanvas?>(null) }
+    var strokes by remember(sharedSpaceId) { mutableStateOf(emptyList<CanvasStroke>()) }
+    var currentStroke by remember { mutableStateOf<CanvasStroke?>(null) }
+    var selectedTool by remember { mutableStateOf(CanvasTool.Pen) }
+    var selectedColor by remember { mutableStateOf("#3D2C2E") }
+    var lineWidth by remember { mutableStateOf(6f) }
+    var message by remember { mutableStateOf<String?>(null) }
+
+    LaunchedEffect(sharedSpaceId) {
+        when (val result = repository.fetchCanvas(sharedSpaceId)) {
+            is DataResult.Success -> canvas = result.data
+            is DataResult.Failure -> message = result.message
+        }
+        when (val result = repository.fetchStrokes(sharedSpaceId)) {
+            is DataResult.Success -> strokes = result.data
+            is DataResult.Failure -> message = result.message
+        }
+    }
+
+    Column(modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        Text("우리 낙서장")
+        message?.let { Text(it) }
+        Canvas(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(420.dp)
+                .background(Color(0xFFFAEDDB), RoundedCornerShape(24.dp))
+                .pointerInput(canvas?.id, selectedTool, selectedColor, lineWidth) {
+                    detectDragGestures(
+                        onDragStart = { offset ->
+                            val activeCanvas = canvas ?: return@detectDragGestures
+                            val sequence = (strokes.maxOfOrNull { it.sequence } ?: 0) + 1
+                            currentStroke = CanvasStroke(
+                                id = "stroke-${System.currentTimeMillis()}",
+                                canvasId = activeCanvas.id,
+                                sharedSpaceId = sharedSpaceId,
+                                authorId = "local",
+                                sequence = sequence,
+                                tool = selectedTool,
+                                colorHex = selectedColor,
+                                lineWidth = lineWidth,
+                                points = listOf(offset.toCanvasPoint(size.width.toFloat(), size.height.toFloat())),
+                            )
+                        },
+                        onDrag = { change, _ ->
+                            currentStroke = currentStroke?.copy(points = currentStroke!!.points + change.position.toCanvasPoint(size.width.toFloat(), size.height.toFloat()))
+                        },
+                        onDragEnd = {
+                            currentStroke?.let { stroke ->
+                                val stored = when (val result = repository.appendStroke(stroke)) {
+                                    is DataResult.Success -> result.data
+                                    is DataResult.Failure -> {
+                                        message = result.message
+                                        stroke
+                                    }
+                                }
+                                strokes = strokes + stored
+                                if (snapshotThrottle.shouldUpdate()) {
+                                    val file = File(context.filesDir, "canvas/snapshots/${sharedSpaceId}.png")
+                                    renderer.writePng(strokes, file)
+                                    repository.updateSnapshot(
+                                        CanvasSnapshot(
+                                            id = "snapshot-${System.currentTimeMillis()}",
+                                            canvasId = stored.canvasId,
+                                            sharedSpaceId = sharedSpaceId,
+                                            version = stored.sequence,
+                                            localPath = file.absolutePath,
+                                            width = 800,
+                                            height = 800,
+                                        ),
+                                    )
+                                }
+                            }
+                            currentStroke = null
+                        },
+                    )
+                },
+        ) {
+            (strokes + listOfNotNull(currentStroke)).sortedBy { it.sequence }.forEach { stroke ->
+                stroke.points.zipWithNext().forEach { (from, to) ->
+                    drawLine(
+                        color = if (stroke.tool == CanvasTool.Eraser) Color(0xFFFAEDDB) else Color(android.graphics.Color.parseColor(stroke.colorHex)),
+                        start = Offset(from.x * size.width, from.y * size.height),
+                        end = Offset(to.x * size.width, to.y * size.height),
+                        strokeWidth = stroke.lineWidth,
+                        cap = StrokeCap.Round,
+                    )
+                }
+            }
+        }
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.fillMaxWidth()) {
+            FilterChip(selected = selectedTool == CanvasTool.Pen, onClick = { selectedTool = CanvasTool.Pen }, label = { Text("펜") })
+            FilterChip(selected = selectedTool == CanvasTool.Eraser, onClick = { selectedTool = CanvasTool.Eraser }, label = { Text("지우개") })
+            Button(onClick = { selectedColor = "#D96C4A" }) { Text("테라코타") }
+            Button(onClick = {
+                repository.clearCanvas(sharedSpaceId)
+                strokes = emptyList()
+            }) { Text("전체 지우기") }
+        }
+        Slider(value = lineWidth, onValueChange = { lineWidth = it }, valueRange = 2f..24f)
+    }
+}
+
+private fun Offset.toCanvasPoint(width: Float, height: Float): CanvasPoint = CanvasPoint(
+    x = x / width.coerceAtLeast(1f),
+    y = y / height.coerceAtLeast(1f),
+    t = System.currentTimeMillis().toDouble(),
+).normalized()

--- a/android_memorybox/app/src/main/java/com/memorybox/android/canvas/CanvasScreen.kt
+++ b/android_memorybox/app/src/main/java/com/memorybox/android/canvas/CanvasScreen.kt
@@ -56,6 +56,7 @@ fun CanvasScreen(
     var selectedColor by remember { mutableStateOf("#3D2C2E") }
     var lineWidth by remember { mutableStateOf(6f) }
     var message by remember { mutableStateOf<String?>(null) }
+    val snapshotNotifier = remember(context) { CanvasSnapshotNotifier(context) }
 
     LaunchedEffect(sharedSpaceId) {
         when (val result = repository.fetchCanvas(sharedSpaceId)) {
@@ -109,17 +110,17 @@ fun CanvasScreen(
                                 if (snapshotThrottle.shouldUpdate()) {
                                     val file = File(context.filesDir, "canvas/snapshots/${sharedSpaceId}.png")
                                     renderer.writePng(strokes, file)
-                                    repository.updateSnapshot(
-                                        CanvasSnapshot(
-                                            id = "snapshot-${System.currentTimeMillis()}",
-                                            canvasId = stored.canvasId,
-                                            sharedSpaceId = sharedSpaceId,
-                                            version = stored.sequence,
-                                            localPath = file.absolutePath,
-                                            width = 800,
-                                            height = 800,
-                                        ),
+                                    val snapshot = CanvasSnapshot(
+                                        id = "snapshot-${System.currentTimeMillis()}",
+                                        canvasId = stored.canvasId,
+                                        sharedSpaceId = sharedSpaceId,
+                                        version = stored.sequence,
+                                        localPath = file.absolutePath,
+                                        width = 800,
+                                        height = 800,
                                     )
+                                    repository.updateSnapshot(snapshot)
+                                    snapshotNotifier.showLatest(snapshot)
                                 }
                             }
                             currentStroke = null

--- a/android_memorybox/app/src/main/java/com/memorybox/android/canvas/CanvasScreen.kt
+++ b/android_memorybox/app/src/main/java/com/memorybox/android/canvas/CanvasScreen.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -25,7 +24,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
-import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
@@ -80,19 +78,20 @@ fun CanvasScreen(
                 .pointerInput(canvas?.id, selectedTool, selectedColor, lineWidth) {
                     detectDragGestures(
                         onDragStart = { offset ->
-                            val activeCanvas = canvas ?: return@detectDragGestures
-                            val sequence = (strokes.maxOfOrNull { it.sequence } ?: 0) + 1
-                            currentStroke = CanvasStroke(
-                                id = "stroke-${System.currentTimeMillis()}",
-                                canvasId = activeCanvas.id,
-                                sharedSpaceId = sharedSpaceId,
-                                authorId = "local",
-                                sequence = sequence,
-                                tool = selectedTool,
-                                colorHex = selectedColor,
-                                lineWidth = lineWidth,
-                                points = listOf(offset.toCanvasPoint(size.width.toFloat(), size.height.toFloat())),
-                            )
+                            canvas?.let { activeCanvas ->
+                                val sequence = (strokes.maxOfOrNull { it.sequence } ?: 0) + 1
+                                currentStroke = CanvasStroke(
+                                    id = "stroke-${System.currentTimeMillis()}",
+                                    canvasId = activeCanvas.id,
+                                    sharedSpaceId = sharedSpaceId,
+                                    authorId = "local",
+                                    sequence = sequence,
+                                    tool = selectedTool,
+                                    colorHex = selectedColor,
+                                    lineWidth = lineWidth,
+                                    points = listOf(offset.toCanvasPoint(size.width.toFloat(), size.height.toFloat())),
+                                )
+                            }
                         },
                         onDrag = { change, _ ->
                             currentStroke = currentStroke?.copy(points = currentStroke!!.points + change.position.toCanvasPoint(size.width.toFloat(), size.height.toFloat()))

--- a/android_memorybox/app/src/main/java/com/memorybox/android/canvas/CanvasSnapshotNotifier.kt
+++ b/android_memorybox/app/src/main/java/com/memorybox/android/canvas/CanvasSnapshotNotifier.kt
@@ -1,0 +1,46 @@
+package com.memorybox.android.canvas
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.graphics.BitmapFactory
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import com.memorybox.android.R
+import java.io.File
+
+class CanvasSnapshotNotifier(
+    private val context: Context,
+) {
+    fun showLatest(snapshot: CanvasSnapshot) {
+        val file = snapshot.localPath?.let(::File) ?: return
+        if (!file.exists()) return
+        ensureChannel()
+        val bitmap = BitmapFactory.decodeFile(file.absolutePath) ?: return
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_launcher)
+            .setContentTitle("우리 낙서장")
+            .setContentText("새 낙서가 도착했어요")
+            .setStyle(NotificationCompat.BigPictureStyle().bigPicture(bitmap))
+            .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+            .setOnlyAlertOnce(true)
+            .setOngoing(false)
+            .build()
+        runCatching { NotificationManagerCompat.from(context).notify(NOTIFICATION_ID, notification) }
+    }
+
+    private fun ensureChannel() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        val channel = NotificationChannel(CHANNEL_ID, "우리 낙서장", NotificationManager.IMPORTANCE_LOW).apply {
+            description = "페어링된 낙서장 최신 스냅샷"
+            lockscreenVisibility = android.app.Notification.VISIBILITY_PUBLIC
+        }
+        context.getSystemService(NotificationManager::class.java).createNotificationChannel(channel)
+    }
+
+    companion object {
+        private const val CHANNEL_ID = "live_canvas_snapshot"
+        private const val NOTIFICATION_ID = 2808
+    }
+}

--- a/android_memorybox/app/src/main/java/com/memorybox/android/canvas/CanvasSnapshotRenderer.kt
+++ b/android_memorybox/app/src/main/java/com/memorybox/android/canvas/CanvasSnapshotRenderer.kt
@@ -1,0 +1,42 @@
+package com.memorybox.android.canvas
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import java.io.File
+import java.io.FileOutputStream
+
+class CanvasSnapshotRenderer(
+    private val width: Int = 800,
+    private val height: Int = 800,
+    private val backgroundColor: Int = Color.rgb(250, 237, 219),
+) {
+    fun render(strokes: List<CanvasStroke>): Bitmap {
+        val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bitmap)
+        canvas.drawColor(backgroundColor)
+        strokes.sortedBy { it.sequence }.forEach { stroke -> drawStroke(canvas, stroke) }
+        return bitmap
+    }
+
+    fun writePng(strokes: List<CanvasStroke>, file: File): File {
+        file.parentFile?.mkdirs()
+        FileOutputStream(file).use { out -> render(strokes).compress(Bitmap.CompressFormat.PNG, 100, out) }
+        return file
+    }
+
+    private fun drawStroke(canvas: Canvas, stroke: CanvasStroke) {
+        if (stroke.points.size < 2) return
+        val paint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            style = Paint.Style.STROKE
+            strokeCap = Paint.Cap.ROUND
+            strokeJoin = Paint.Join.ROUND
+            strokeWidth = stroke.lineWidth
+            color = if (stroke.tool == CanvasTool.Eraser) backgroundColor else runCatching { Color.parseColor(stroke.colorHex) }.getOrDefault(Color.rgb(61, 44, 46))
+        }
+        stroke.points.zipWithNext().forEach { (from, to) ->
+            canvas.drawLine(from.x * width, from.y * height, to.x * width, to.y * height, paint)
+        }
+    }
+}

--- a/android_memorybox/app/src/main/java/com/memorybox/android/canvas/SnapshotThrottle.kt
+++ b/android_memorybox/app/src/main/java/com/memorybox/android/canvas/SnapshotThrottle.kt
@@ -1,0 +1,16 @@
+package com.memorybox.android.canvas
+
+class SnapshotThrottle(
+    private val minIntervalMillis: Long = 2_000,
+) {
+    private var lastUpdateMillis: Long? = null
+
+    fun shouldUpdate(nowMillis: Long = System.currentTimeMillis()): Boolean {
+        val last = lastUpdateMillis
+        if (last == null || nowMillis - last >= minIntervalMillis) {
+            lastUpdateMillis = nowMillis
+            return true
+        }
+        return false
+    }
+}

--- a/android_memorybox/app/src/main/java/com/memorybox/android/core/network/MemoryBoxEndpoints.kt
+++ b/android_memorybox/app/src/main/java/com/memorybox/android/core/network/MemoryBoxEndpoints.kt
@@ -25,4 +25,12 @@ object MemoryBoxEndpoints {
         fun accept(friendId: String) = "/friend/accept/$friendId"
         fun friend(friendId: String) = "/friend/$friendId"
     }
+
+    object SharedSpace {
+        const val active = "/shared-spaces/active"
+        const val invites = "/shared-spaces/invites"
+
+        fun acceptInvite(code: String) = "/shared-spaces/invites/$code/accept"
+        fun leave(id: String) = "/shared-spaces/$id/members/me"
+    }
 }

--- a/android_memorybox/app/src/main/java/com/memorybox/android/friend/FriendScreen.kt
+++ b/android_memorybox/app/src/main/java/com/memorybox/android/friend/FriendScreen.kt
@@ -111,6 +111,9 @@ fun FriendScreen(
 
         Spacer(Modifier.height(8.dp))
         Text("친구 요청", style = MaterialTheme.typography.titleMedium)
+        if (!screenState.isLoading && screenState.requests.isEmpty()) {
+            Text("받거나 보낸 친구 요청이 없습니다.", style = MaterialTheme.typography.bodyMedium)
+        }
         screenState.requests.forEach { request ->
             val isMyRequest = request.senderId == userId
             Row(
@@ -167,6 +170,9 @@ fun FriendScreen(
         }
 
         Text("친구 목록", style = MaterialTheme.typography.titleMedium)
+        if (!screenState.isLoading && screenState.friends.isEmpty()) {
+            Text("아직 등록된 친구가 없습니다.", style = MaterialTheme.typography.bodyMedium)
+        }
         screenState.friends.forEach { friend ->
             Row(
                 modifier = Modifier.fillMaxWidth(),

--- a/android_memorybox/app/src/main/java/com/memorybox/android/friend/FriendScreen.kt
+++ b/android_memorybox/app/src/main/java/com/memorybox/android/friend/FriendScreen.kt
@@ -23,6 +23,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.memorybox.android.core.network.DataResult
+import com.memorybox.android.pairing.LocalPairingRepository
+import com.memorybox.android.pairing.PairingRepository
+import com.memorybox.android.pairing.PairingScreen
 import kotlinx.coroutines.launch
 
 @Composable
@@ -30,6 +33,7 @@ fun FriendScreen(
     userId: String,
     modifier: Modifier = Modifier,
     repository: FriendRepository = remember(userId) { LocalFriendRepository(userId) },
+    pairingRepository: PairingRepository = remember(userId) { LocalPairingRepository(userId) },
 ) {
     var inviteCode by remember { mutableStateOf("") }
     var screenState by remember(repository) { mutableStateOf(FriendScreenState(isLoading = true)) }
@@ -76,6 +80,11 @@ fun FriendScreen(
     ) {
         Text("친구", style = MaterialTheme.typography.titleLarge)
         Text("uid : $userId", style = MaterialTheme.typography.bodyMedium)
+
+        PairingScreen(
+            userId = userId,
+            repository = pairingRepository,
+        )
 
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
             OutlinedTextField(

--- a/android_memorybox/app/src/main/java/com/memorybox/android/map/data/TripStore.kt
+++ b/android_memorybox/app/src/main/java/com/memorybox/android/map/data/TripStore.kt
@@ -2,11 +2,15 @@ package com.memorybox.android.map.data
 
 import android.content.Context
 import com.memorybox.android.map.domain.Trip
+import com.memorybox.android.pairing.SharedPreferencesActiveSharedSpaceStore
 import java.io.File
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
 
-class TripStore(private val storageFile: File) {
+class TripStore(
+    private val storageFile: File,
+    private val activeSharedSpaceIdProvider: () -> String? = { null },
+) {
     private val json = Json {
         ignoreUnknownKeys = true
         prettyPrint = true
@@ -28,8 +32,17 @@ class TripStore(private val storageFile: File) {
 
     fun upsert(trip: Trip) {
         val trips = loadAll().toMutableMap()
-        trips[trip.sigunguCode] = trip
+        trips[trip.sigunguCode] = trip.withDefaultSharedSpaceId()
         saveAll(trips.values)
+    }
+
+    private fun Trip.withDefaultSharedSpaceId(): Trip {
+        val activeSharedSpaceId = activeSharedSpaceIdProvider()?.takeIf { it.isNotBlank() }
+        return if (sharedSpaceId == null && activeSharedSpaceId != null) {
+            copy(sharedSpaceId = activeSharedSpaceId)
+        } else {
+            this
+        }
     }
 
     fun delete(sigunguCode: Int): Trip? {
@@ -59,6 +72,9 @@ class TripStore(private val storageFile: File) {
     companion object {
         private const val FILE_NAME = "map_trips.json"
 
-        fun appPrivate(context: Context): TripStore = TripStore(File(context.filesDir, FILE_NAME))
+        fun appPrivate(context: Context): TripStore = TripStore(
+            storageFile = File(context.filesDir, FILE_NAME),
+            activeSharedSpaceIdProvider = { SharedPreferencesActiveSharedSpaceStore(context).load()?.id },
+        )
     }
 }

--- a/android_memorybox/app/src/main/java/com/memorybox/android/map/domain/MapModels.kt
+++ b/android_memorybox/app/src/main/java/com/memorybox/android/map/domain/MapModels.kt
@@ -23,4 +23,5 @@ data class Trip(
     val scale: Float = 1f,
     val centerX: Float = 0f,
     val centerY: Float = 0f,
+    val sharedSpaceId: String? = null,
 )

--- a/android_memorybox/app/src/main/java/com/memorybox/android/map/ui/MapScreen.kt
+++ b/android_memorybox/app/src/main/java/com/memorybox/android/map/ui/MapScreen.kt
@@ -71,6 +71,7 @@ fun MapScreen(modifier: Modifier = Modifier) {
             scale = trip?.scale ?: 1f,
             centerX = trip?.centerX ?: 0f,
             centerY = trip?.centerY ?: 0f,
+            sharedSpaceId = trip?.sharedSpaceId,
         )
         imageError = null
     }
@@ -381,6 +382,7 @@ private data class TripEditorState(
     val scale: Float,
     val centerX: Float,
     val centerY: Float,
+    val sharedSpaceId: String? = null,
     val newImages: List<String> = emptyList(),
     val removedImages: List<String> = emptyList(),
 ) {
@@ -393,6 +395,7 @@ private data class TripEditorState(
         scale = scale,
         centerX = centerX,
         centerY = centerY,
+        sharedSpaceId = sharedSpaceId,
     )
 }
 

--- a/android_memorybox/app/src/main/java/com/memorybox/android/map/ui/MapScreen.kt
+++ b/android_memorybox/app/src/main/java/com/memorybox/android/map/ui/MapScreen.kt
@@ -124,11 +124,12 @@ fun MapScreen(modifier: Modifier = Modifier) {
             .padding(12.dp),
     ) {
         Text("여행지도", style = MaterialTheme.typography.titleLarge)
+        Text("지역을 선택해 여행 기록을 남겨보세요.", style = MaterialTheme.typography.bodyMedium)
         Box(Modifier.fillMaxSize()) {
             if (error != null) {
                 Text(error.orEmpty())
             } else if (polygons.isEmpty()) {
-                Text("Loading GeoJSON...")
+                Text("지도 데이터를 불러오는 중입니다...")
             } else {
                 SigunguCanvas(
                     polygons = polygons,

--- a/android_memorybox/app/src/main/java/com/memorybox/android/pairing/PairingModels.kt
+++ b/android_memorybox/app/src/main/java/com/memorybox/android/pairing/PairingModels.kt
@@ -1,0 +1,26 @@
+package com.memorybox.android.pairing
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SharedSpace(
+    val id: String,
+    val type: String = "pair",
+    val name: String? = null,
+    val members: List<SharedSpaceMember> = emptyList(),
+)
+
+@Serializable
+data class SharedSpaceMember(
+    val userId: String,
+    val name: String,
+    val role: String = "member",
+)
+
+@Serializable
+data class PairingInvite(
+    val code: String,
+    val sharedSpaceId: String? = null,
+    val inviterId: String,
+    val expiresAt: String? = null,
+)

--- a/android_memorybox/app/src/main/java/com/memorybox/android/pairing/PairingRepository.kt
+++ b/android_memorybox/app/src/main/java/com/memorybox/android/pairing/PairingRepository.kt
@@ -1,0 +1,190 @@
+package com.memorybox.android.pairing
+
+import android.content.Context
+import com.memorybox.android.core.network.ApiResponse
+import com.memorybox.android.core.network.DataResult
+import com.memorybox.android.core.network.MemoryBoxEndpoints
+import com.memorybox.android.friend.FriendHttpMethod
+import com.memorybox.android.friend.FriendHttpRequest
+import com.memorybox.android.friend.FriendTransport
+import java.util.UUID
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.builtins.nullable
+import kotlinx.serialization.json.Json
+
+interface PairingRepository {
+    suspend fun fetchActiveSharedSpace(): DataResult<SharedSpace?>
+    suspend fun createPairingInvite(): DataResult<PairingInvite>
+    suspend fun acceptPairingInvite(code: String): DataResult<SharedSpace>
+    suspend fun leaveSharedSpace(id: String): DataResult<SharedSpace>
+}
+
+interface ActiveSharedSpaceStore {
+    fun load(): SharedSpace?
+    fun save(sharedSpace: SharedSpace)
+    fun clear()
+}
+
+class SharedPreferencesActiveSharedSpaceStore(
+    context: Context,
+    private val json: Json = Json { ignoreUnknownKeys = true },
+) : ActiveSharedSpaceStore {
+    private val preferences = context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
+
+    override fun load(): SharedSpace? {
+        val raw = preferences.getString(KEY_ACTIVE_SHARED_SPACE, null)?.takeIf { it.isNotBlank() }
+            ?: return null
+        return runCatching { json.decodeFromString(SharedSpace.serializer(), raw) }.getOrNull()
+    }
+
+    override fun save(sharedSpace: SharedSpace) {
+        preferences.edit()
+            .putString(KEY_ACTIVE_SHARED_SPACE, json.encodeToString(SharedSpace.serializer(), sharedSpace))
+            .apply()
+    }
+
+    override fun clear() {
+        preferences.edit().remove(KEY_ACTIVE_SHARED_SPACE).apply()
+    }
+
+    private companion object {
+        const val PREF_NAME = "memorybox_pairing"
+        const val KEY_ACTIVE_SHARED_SPACE = "activeSharedSpace"
+    }
+}
+
+class NetworkPairingRepository(
+    private val transport: FriendTransport,
+    private val store: ActiveSharedSpaceStore? = null,
+    private val json: Json = Json { ignoreUnknownKeys = true },
+) : PairingRepository {
+    override suspend fun fetchActiveSharedSpace(): DataResult<SharedSpace?> =
+        executeNullable(
+            request = FriendHttpRequest(FriendHttpMethod.Get, MemoryBoxEndpoints.SharedSpace.active),
+            serializer = SharedSpace.serializer(),
+        ) { sharedSpace ->
+            if (sharedSpace != null) store?.save(sharedSpace)
+        }
+
+    override suspend fun createPairingInvite(): DataResult<PairingInvite> =
+        execute(
+            request = FriendHttpRequest(FriendHttpMethod.Post, MemoryBoxEndpoints.SharedSpace.invites),
+            serializer = PairingInvite.serializer(),
+        )
+
+    override suspend fun acceptPairingInvite(code: String): DataResult<SharedSpace> =
+        execute(
+            request = FriendHttpRequest(FriendHttpMethod.Post, MemoryBoxEndpoints.SharedSpace.acceptInvite(code)),
+            serializer = SharedSpace.serializer(),
+        ) { sharedSpace -> store?.save(sharedSpace) }
+
+    override suspend fun leaveSharedSpace(id: String): DataResult<SharedSpace> =
+        execute(
+            request = FriendHttpRequest(FriendHttpMethod.Delete, MemoryBoxEndpoints.SharedSpace.leave(id)),
+            serializer = SharedSpace.serializer(),
+        ) { store?.clear() }
+
+    private suspend fun <T> execute(
+        request: FriendHttpRequest,
+        serializer: KSerializer<T>,
+        onSuccess: (T) -> Unit = {},
+    ): DataResult<T> =
+        try {
+            val response = transport.request(request)
+            val apiResponse = json.decodeFromString(ApiResponse.serializer(serializer), response.body)
+            val message = apiResponse.message
+
+            if (response.statusCode !in 200..299 || !apiResponse.success) {
+                DataResult.Failure(message.ifBlank { "서버 요청에 실패했습니다." })
+            } else {
+                apiResponse.data?.let { data ->
+                    onSuccess(data)
+                    DataResult.Success(data, message)
+                } ?: DataResult.Failure(message.ifBlank { "서버 응답 데이터가 없습니다." })
+            }
+        } catch (error: Throwable) {
+            DataResult.Failure("서버와의 통신에 에러가 발생했습니다.", error)
+        }
+
+    private suspend fun <T> executeNullable(
+        request: FriendHttpRequest,
+        serializer: KSerializer<T>,
+        onSuccess: (T?) -> Unit = {},
+    ): DataResult<T?> =
+        try {
+            val response = transport.request(request)
+            val apiResponse = json.decodeFromString(ApiResponse.serializer(serializer.nullable), response.body)
+            val message = apiResponse.message
+
+            if (response.statusCode !in 200..299 || !apiResponse.success) {
+                DataResult.Failure(message.ifBlank { "서버 요청에 실패했습니다." })
+            } else {
+                onSuccess(apiResponse.data)
+                DataResult.Success(apiResponse.data, message)
+            }
+        } catch (error: Throwable) {
+            DataResult.Failure("서버와의 통신에 에러가 발생했습니다.", error)
+        }
+}
+
+class LocalPairingRepository(
+    private val userId: String = "",
+    private val store: ActiveSharedSpaceStore = InMemoryActiveSharedSpaceStore(),
+    private val codeProvider: () -> String = { UUID.randomUUID().toString().take(6).uppercase() },
+    private val idProvider: () -> String = { "local_${UUID.randomUUID()}" },
+) : PairingRepository {
+    private var pendingInvite: PairingInvite? = null
+
+    override suspend fun fetchActiveSharedSpace(): DataResult<SharedSpace?> =
+        DataResult.Success(store.load())
+
+    override suspend fun createPairingInvite(): DataResult<PairingInvite> {
+        val invite = PairingInvite(
+            code = codeProvider(),
+            sharedSpaceId = store.load()?.id,
+            inviterId = userId,
+        )
+        pendingInvite = invite
+        return DataResult.Success(invite)
+    }
+
+    override suspend fun acceptPairingInvite(code: String): DataResult<SharedSpace> {
+        if (code.isBlank()) {
+            return DataResult.Failure("페어링 코드를 입력해주세요.")
+        }
+
+        val sharedSpace = SharedSpace(
+            id = pendingInvite?.sharedSpaceId ?: idProvider(),
+            members = listOf(
+                SharedSpaceMember(userId = userId.ifBlank { "me" }, name = userId.ifBlank { "나" }, role = "owner"),
+                SharedSpaceMember(userId = "partner", name = "파트너"),
+            ),
+        )
+        store.save(sharedSpace)
+        pendingInvite = null
+        return DataResult.Success(sharedSpace)
+    }
+
+    override suspend fun leaveSharedSpace(id: String): DataResult<SharedSpace> {
+        val sharedSpace = store.load() ?: SharedSpace(id = id)
+        store.clear()
+        pendingInvite = null
+        return DataResult.Success(sharedSpace)
+    }
+}
+
+class InMemoryActiveSharedSpaceStore(
+    initialSharedSpace: SharedSpace? = null,
+) : ActiveSharedSpaceStore {
+    private var sharedSpace = initialSharedSpace
+
+    override fun load(): SharedSpace? = sharedSpace
+
+    override fun save(sharedSpace: SharedSpace) {
+        this.sharedSpace = sharedSpace
+    }
+
+    override fun clear() {
+        sharedSpace = null
+    }
+}

--- a/android_memorybox/app/src/main/java/com/memorybox/android/pairing/PairingScreen.kt
+++ b/android_memorybox/app/src/main/java/com/memorybox/android/pairing/PairingScreen.kt
@@ -1,0 +1,164 @@
+package com.memorybox.android.pairing
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.memorybox.android.core.network.DataResult
+import kotlinx.coroutines.launch
+
+@Composable
+fun PairingScreen(
+    userId: String,
+    modifier: Modifier = Modifier,
+    repository: PairingRepository = remember(userId) { LocalPairingRepository(userId) },
+) {
+    var screenState by remember(repository) { mutableStateOf(PairingScreenState(isLoading = true)) }
+    var pairingCode by remember { mutableStateOf("") }
+    val coroutineScope = rememberCoroutineScope()
+
+    LaunchedEffect(repository) {
+        screenState = screenState.copy(isLoading = true, errorMessage = null)
+        screenState = when (val result = repository.fetchActiveSharedSpace()) {
+            is DataResult.Success -> screenState.copy(
+                isLoading = false,
+                activeSharedSpace = result.data,
+                errorMessage = null,
+            )
+            is DataResult.Failure -> screenState.copy(
+                isLoading = false,
+                errorMessage = result.message,
+            )
+        }
+    }
+
+    fun <T> runPairingAction(
+        action: suspend () -> DataResult<T>,
+        reduce: (PairingScreenState, T) -> PairingScreenState,
+    ) {
+        coroutineScope.launch {
+            screenState = screenState.copy(isLoading = true, errorMessage = null)
+            screenState = when (val result = action()) {
+                is DataResult.Success<*> -> {
+                    @Suppress("UNCHECKED_CAST")
+                    reduce(screenState, result.data as T).copy(isLoading = false, errorMessage = null)
+                }
+                is DataResult.Failure -> screenState.copy(
+                    isLoading = false,
+                    errorMessage = result.message,
+                )
+            }
+        }
+    }
+
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text("페어링", style = MaterialTheme.typography.titleMedium)
+
+        if (screenState.isLoading) {
+            Text("페어링 정보를 불러오는 중...", style = MaterialTheme.typography.bodyMedium)
+        }
+
+        screenState.errorMessage?.let { message ->
+            Text(message, color = MaterialTheme.colorScheme.error)
+        }
+
+        val activeSharedSpace = screenState.activeSharedSpace
+        if (activeSharedSpace != null) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(pairingDescription(activeSharedSpace, userId))
+                Button(
+                    enabled = !screenState.isLoading,
+                    onClick = {
+                        runPairingAction(
+                            action = { repository.leaveSharedSpace(activeSharedSpace.id) },
+                            reduce = { state, _ -> state.copy(activeSharedSpace = null, pairingInvite = null) },
+                        )
+                    },
+                ) {
+                    Text("해제")
+                }
+            }
+        } else {
+            screenState.pairingInvite?.let { invite ->
+                Text("초대 코드: ${invite.code}", color = MaterialTheme.colorScheme.primary)
+            }
+
+            Button(
+                enabled = !screenState.isLoading,
+                onClick = {
+                    runPairingAction(
+                        action = { repository.createPairingInvite() },
+                        reduce = { state, invite -> state.copy(pairingInvite = invite) },
+                    )
+                },
+            ) {
+                Text("초대 코드 생성")
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                OutlinedTextField(
+                    value = pairingCode,
+                    onValueChange = { pairingCode = it },
+                    modifier = Modifier.weight(1f),
+                    label = { Text("페어링 코드") },
+                )
+                Button(
+                    enabled = pairingCode.isNotBlank() && !screenState.isLoading,
+                    onClick = {
+                        val code = pairingCode.trim()
+                        runPairingAction(
+                            action = { repository.acceptPairingInvite(code) },
+                            reduce = { state, sharedSpace ->
+                                pairingCode = ""
+                                state.copy(activeSharedSpace = sharedSpace, pairingInvite = null)
+                            },
+                        )
+                    },
+                ) {
+                    Text("연결")
+                }
+            }
+        }
+    }
+}
+
+private data class PairingScreenState(
+    val isLoading: Boolean = false,
+    val errorMessage: String? = null,
+    val activeSharedSpace: SharedSpace? = null,
+    val pairingInvite: PairingInvite? = null,
+)
+
+private fun pairingDescription(sharedSpace: SharedSpace, userId: String): String {
+    val partner = sharedSpace.members.firstOrNull { it.userId != userId }
+    return when {
+        partner != null -> "${partner.name}님과 페어링 중"
+        !sharedSpace.name.isNullOrBlank() -> "${sharedSpace.name} 공유 공간에 연결됨"
+        else -> "공유 공간에 연결됨"
+    }
+}

--- a/android_memorybox/app/src/main/java/com/memorybox/android/ui/MemoryBoxApp.kt
+++ b/android_memorybox/app/src/main/java/com/memorybox/android/ui/MemoryBoxApp.kt
@@ -98,6 +98,7 @@ fun MemoryBoxApp() {
         CalendarRepositoryImpl(
             store = CalendarJsonStore.appPrivate(context),
             transport = transport,
+            activeSharedSpaceIdProvider = { SharedPreferencesActiveSharedSpaceStore(context).load()?.id },
         )
     }
 
@@ -363,6 +364,7 @@ private fun syncCalendarAfterLogin(
     if (baseUrl.isBlank()) return
     val repository = CalendarRepositoryImpl(
         store = CalendarJsonStore.appPrivate(context),
+        activeSharedSpaceIdProvider = { SharedPreferencesActiveSharedSpaceStore(context).load()?.id },
         transport = NetworkCalendarServerTransport(
             client = UrlConnectionMemoryBoxHttpClient(MemoryBoxConfig(baseUrl)),
             accessTokenProvider = { sessionStore.load()?.accessToken },

--- a/android_memorybox/app/src/main/java/com/memorybox/android/ui/MemoryBoxApp.kt
+++ b/android_memorybox/app/src/main/java/com/memorybox/android/ui/MemoryBoxApp.kt
@@ -40,6 +40,9 @@ import com.memorybox.android.calendar.data.CalendarRepositoryImpl
 import com.memorybox.android.calendar.data.NetworkCalendarServerTransport
 import com.memorybox.android.calendar.data.NoopCalendarServerTransport
 import com.memorybox.android.calendar.ui.CalendarScreen
+import com.memorybox.android.canvas.CanvasJsonStore
+import com.memorybox.android.canvas.CanvasScreen
+import com.memorybox.android.canvas.LocalCanvasRepository
 import com.memorybox.android.core.network.DataResult
 import com.memorybox.android.core.network.MemoryBoxConfig
 import com.memorybox.android.core.network.UrlConnectionMemoryBoxHttpClient
@@ -65,6 +68,7 @@ private enum class SideDestination {
     Home,
     Widget,
     Friend,
+    Canvas,
     Setting,
 }
 
@@ -117,6 +121,11 @@ fun MemoryBoxApp() {
     }
 
     val pairingStore = remember(context) { SharedPreferencesActiveSharedSpaceStore(context) }
+
+    val canvasRepository = remember(context) {
+        LocalCanvasRepository(CanvasJsonStore.appPrivate(context))
+    }
+
     val pairingRepository = remember(activeBaseUrl, session?.accessToken, session?.uid, pairingStore) {
         if (activeBaseUrl.isNotBlank() && session?.accessToken?.isNotBlank() == true) {
             NetworkPairingRepository(
@@ -161,6 +170,10 @@ fun MemoryBoxApp() {
                     },
                     onFriend = {
                         destination = SideDestination.Friend
+                        scope.launch { drawerState.close() }
+                    },
+                    onCanvas = {
+                        destination = SideDestination.Canvas
                         scope.launch { drawerState.close() }
                     },
                     onSetting = {
@@ -227,6 +240,11 @@ fun MemoryBoxApp() {
                     modifier = Modifier.padding(padding),
                     repository = friendRepository,
                     pairingRepository = pairingRepository,
+                )
+                SideDestination.Canvas -> CanvasScreen(
+                    sharedSpaceId = pairingStore.load()?.id,
+                    repository = canvasRepository,
+                    modifier = Modifier.padding(padding),
                 )
                 SideDestination.Setting -> SettingScreen(
                     session = session,
@@ -380,6 +398,7 @@ private fun SideMenu(
     onLogin: () -> Unit,
     onWidget: () -> Unit,
     onFriend: () -> Unit,
+    onCanvas: () -> Unit,
     onSetting: () -> Unit,
     onLogout: () -> Unit,
     onDeleteUser: () -> Unit,
@@ -405,6 +424,9 @@ private fun SideMenu(
         if (session != null) {
             Button(onClick = onFriend, modifier = Modifier.fillMaxWidth()) {
                 Text("친구")
+            }
+            Button(onClick = onCanvas, modifier = Modifier.fillMaxWidth()) {
+                Text("우리 낙서장")
             }
         }
 

--- a/android_memorybox/app/src/main/java/com/memorybox/android/ui/MemoryBoxApp.kt
+++ b/android_memorybox/app/src/main/java/com/memorybox/android/ui/MemoryBoxApp.kt
@@ -48,6 +48,9 @@ import com.memorybox.android.friend.HttpUrlConnectionFriendTransport
 import com.memorybox.android.friend.LocalFriendRepository
 import com.memorybox.android.friend.NetworkFriendRepository
 import com.memorybox.android.map.ui.MapScreen
+import com.memorybox.android.pairing.LocalPairingRepository
+import com.memorybox.android.pairing.NetworkPairingRepository
+import com.memorybox.android.pairing.SharedPreferencesActiveSharedSpaceStore
 import com.memorybox.android.widget.ui.DdayScreen
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -109,6 +112,25 @@ fun MemoryBoxApp() {
             )
         } else {
             LocalFriendRepository(session?.uid.orEmpty())
+        }
+    }
+
+    val pairingStore = remember(context) { SharedPreferencesActiveSharedSpaceStore(context) }
+    val pairingRepository = remember(activeBaseUrl, session?.accessToken, session?.uid, pairingStore) {
+        if (activeBaseUrl.isNotBlank() && session?.accessToken?.isNotBlank() == true) {
+            NetworkPairingRepository(
+                transport = HttpUrlConnectionFriendTransport(
+                    baseUrl = activeBaseUrl,
+                    bearerTokenProvider = { sessionStore.load()?.accessToken },
+                    refreshTokenProvider = { refreshAccessToken(activeBaseUrl, sessionStore) },
+                ),
+                store = pairingStore,
+            )
+        } else {
+            LocalPairingRepository(
+                userId = session?.uid.orEmpty(),
+                store = pairingStore,
+            )
         }
     }
 
@@ -203,6 +225,7 @@ fun MemoryBoxApp() {
                     userId = session?.uid.orEmpty(),
                     modifier = Modifier.padding(padding),
                     repository = friendRepository,
+                    pairingRepository = pairingRepository,
                 )
                 SideDestination.Setting -> SettingScreen(
                     session = session,

--- a/android_memorybox/app/src/main/java/com/memorybox/android/ui/MemoryBoxApp.kt
+++ b/android_memorybox/app/src/main/java/com/memorybox/android/ui/MemoryBoxApp.kt
@@ -1,5 +1,6 @@
 package com.memorybox.android.ui
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -8,6 +9,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.DrawerValue
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.ModalDrawerSheet
 import androidx.compose.material3.ModalNavigationDrawer
 import androidx.compose.material3.NavigationBar
@@ -60,6 +62,7 @@ private enum class SideDestination {
     Home,
     Widget,
     Friend,
+    Setting,
 }
 
 @Composable
@@ -137,6 +140,10 @@ fun MemoryBoxApp() {
                         destination = SideDestination.Friend
                         scope.launch { drawerState.close() }
                     },
+                    onSetting = {
+                        destination = SideDestination.Setting
+                        scope.launch { drawerState.close() }
+                    },
                     onLogout = {
                         sessionStore.clear()
                         session = null
@@ -196,6 +203,11 @@ fun MemoryBoxApp() {
                     userId = session?.uid.orEmpty(),
                     modifier = Modifier.padding(padding),
                     repository = friendRepository,
+                )
+                SideDestination.Setting -> SettingScreen(
+                    session = session,
+                    activeBaseUrl = activeBaseUrl,
+                    modifier = Modifier.padding(padding),
                 )
             }
         }
@@ -343,10 +355,14 @@ private fun SideMenu(
     onLogin: () -> Unit,
     onWidget: () -> Unit,
     onFriend: () -> Unit,
+    onSetting: () -> Unit,
     onLogout: () -> Unit,
     onDeleteUser: () -> Unit,
 ) {
-    Column(Modifier.padding(20.dp)) {
+    Column(
+        modifier = Modifier.padding(20.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
         if (session == null) {
             Button(onClick = onLogin, modifier = Modifier.fillMaxWidth()) {
                 Text("로그인")
@@ -354,6 +370,8 @@ private fun SideMenu(
         } else {
             Text("${session.userName} 님 환영합니다.")
         }
+
+        HorizontalDivider()
 
         Button(onClick = onWidget, modifier = Modifier.fillMaxWidth()) {
             Text("위젯")
@@ -363,6 +381,13 @@ private fun SideMenu(
             Button(onClick = onFriend, modifier = Modifier.fillMaxWidth()) {
                 Text("친구")
             }
+        }
+
+        Button(onClick = onSetting, modifier = Modifier.fillMaxWidth()) {
+            Text("설정")
+        }
+
+        if (session != null) {
             Button(onClick = onDeleteUser, modifier = Modifier.fillMaxWidth()) {
                 Text("회원탈퇴")
             }
@@ -370,6 +395,29 @@ private fun SideMenu(
                 Text("로그아웃")
             }
         }
+    }
+}
+
+@Composable
+private fun SettingScreen(
+    session: UserSession?,
+    activeBaseUrl: String,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Text("설정", style = androidx.compose.material3.MaterialTheme.typography.titleLarge)
+        Text("앱 정보", style = androidx.compose.material3.MaterialTheme.typography.titleMedium)
+        Text("앱 이름: MemoryBox")
+        Text("빌드 타입: ${BuildConfig.BUILD_TYPE}")
+        Text("서버 주소: ${activeBaseUrl.ifBlank { "설정되지 않음" }}")
+
+        HorizontalDivider()
+
+        Text("계정", style = androidx.compose.material3.MaterialTheme.typography.titleMedium)
+        Text(session?.userName?.let { "$it 님으로 로그인됨" } ?: "로그인되어 있지 않습니다.")
     }
 }
 

--- a/android_memorybox/app/src/main/java/com/memorybox/android/widget/data/DdayWidgetStore.kt
+++ b/android_memorybox/app/src/main/java/com/memorybox/android/widget/data/DdayWidgetStore.kt
@@ -2,6 +2,7 @@ package com.memorybox.android.widget.data
 
 import android.content.Context
 import android.content.SharedPreferences
+import com.memorybox.android.pairing.SharedPreferencesActiveSharedSpaceStore
 import com.memorybox.android.widget.domain.DdayWidgetItem
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.encodeToString
@@ -24,7 +25,7 @@ object DdayWidgetStore {
     }
 
     fun upsert(context: Context, item: DdayWidgetItem) {
-        saveState(context, upsert(loadState(context), item))
+        saveState(context, upsert(loadState(context), item, activeSharedSpaceId(context)))
     }
 
     fun remove(context: Context, id: String) {
@@ -42,13 +43,23 @@ object DdayWidgetStore {
     }
 
     fun upsert(state: State, item: DdayWidgetItem): State {
+        return upsert(state, item, activeSharedSpaceId = null)
+    }
+
+    fun upsert(state: State, item: DdayWidgetItem, activeSharedSpaceId: String?): State {
+        val itemWithSharedSpace = item.withDefaultSharedSpaceId(activeSharedSpaceId)
         val existingIndex = state.items.indexOfFirst { it.id == item.id }
         val updatedItems = if (existingIndex >= 0) {
-            state.items.map { existing -> if (existing.id == item.id) item else existing }
+            state.items.map { existing -> if (existing.id == item.id) itemWithSharedSpace else existing }
         } else {
-            state.items + item
+            state.items + itemWithSharedSpace
         }
-        return State(items = updatedItems, selectedId = item.id)
+        return State(items = updatedItems, selectedId = itemWithSharedSpace.id)
+    }
+
+    private fun DdayWidgetItem.withDefaultSharedSpaceId(activeSharedSpaceId: String?): DdayWidgetItem {
+        val id = activeSharedSpaceId?.takeIf { it.isNotBlank() }
+        return if (sharedSpaceId == null && id != null) copy(sharedSpaceId = id) else this
     }
 
     fun remove(state: State, id: String): State {
@@ -104,6 +115,9 @@ object DdayWidgetStore {
         }
         editor.apply()
     }
+
+    private fun activeSharedSpaceId(context: Context): String? =
+        SharedPreferencesActiveSharedSpaceStore(context).load()?.id
 
     private fun normalizeSelectedId(items: List<DdayWidgetItem>, selectedId: String?): String? {
         return selectedId?.takeIf { id -> items.any { it.id == id } } ?: items.firstOrNull()?.id

--- a/android_memorybox/app/src/main/java/com/memorybox/android/widget/domain/DdayModels.kt
+++ b/android_memorybox/app/src/main/java/com/memorybox/android/widget/domain/DdayModels.kt
@@ -28,6 +28,7 @@ data class DdayWidgetItem(
     val dateAlignment: WidgetAlign = WidgetAlign.Center,
     val isShowTitle: Boolean = true,
     val titleAlignment: WidgetAlign = WidgetAlign.Center,
+    val sharedSpaceId: String? = null,
 ) {
     val startDate: LocalDate
         get() = LocalDate.parse(startDateIso)

--- a/android_memorybox/app/src/main/java/com/memorybox/android/widget/ui/DdayScreen.kt
+++ b/android_memorybox/app/src/main/java/com/memorybox/android/widget/ui/DdayScreen.kt
@@ -198,6 +198,9 @@ fun DdayScreen(modifier: Modifier = Modifier) {
                 val oldImagePath = editingId?.let { id ->
                     items.firstOrNull { it.id == id }?.imagePath
                 }
+                val existingSharedSpaceId = editingId?.let { id ->
+                    items.firstOrNull { it.id == id }?.sharedSpaceId
+                }
                 val item = DdayWidgetItem(
                     id = editingId ?: UUID.randomUUID().toString(),
                     title = title,
@@ -207,6 +210,7 @@ fun DdayScreen(modifier: Modifier = Modifier) {
                     dateAlignment = dateAlignment,
                     isShowTitle = isShowTitle,
                     titleAlignment = titleAlignment,
+                    sharedSpaceId = existingSharedSpaceId,
                 )
                 DdayWidgetStore.upsert(context, item)
                 if (

--- a/android_memorybox/app/src/main/java/com/memorybox/android/widget/ui/DdayScreen.kt
+++ b/android_memorybox/app/src/main/java/com/memorybox/android/widget/ui/DdayScreen.kt
@@ -230,6 +230,10 @@ fun DdayScreen(modifier: Modifier = Modifier) {
             }
         }
 
+        if (items.isEmpty()) {
+            Text("등록된 D-Day가 없습니다. 첫 기념일을 추가해보세요.", style = MaterialTheme.typography.bodyMedium)
+        }
+
         items.forEach { item ->
             Card(Modifier.fillMaxWidth()) {
                 Column(

--- a/android_memorybox/app/src/test/java/com/memorybox/android/calendar/CalendarRepositoryTest.kt
+++ b/android_memorybox/app/src/test/java/com/memorybox/android/calendar/CalendarRepositoryTest.kt
@@ -121,6 +121,53 @@ class CalendarRepositoryTest {
     }
 
     @Test
+    fun newRecordsUseActiveSharedSpaceWhenNoExplicitSharingExists() {
+        val repository = repository(
+            tempStoreFile(),
+            ids = mutableListOf("local_todo", "local_diary", "local_schedule"),
+            activeSharedSpaceId = "space-1",
+        )
+
+        val todo = repository.updateTodo(Todo(title = "Todo", endDate = LocalDate.of(2026, 4, 7)))
+        val diary = repository.updateDiary(Diary(date = LocalDate.of(2026, 4, 7), content = "Diary"))
+        val schedule = repository.updateSchedule(
+            Schedule(title = "Schedule", startDate = LocalDate.of(2026, 4, 7), endDate = LocalDate.of(2026, 4, 8))
+        )
+
+        val payload = repository.buildSyncPayload()
+
+        assertEquals("space-1", todo.sharedSpaceId)
+        assertEquals(listOf("space-1"), todo.shared)
+        assertEquals("space-1", diary.sharedSpaceId)
+        assertEquals("space-1", schedule.sharedSpaceId)
+        assertEquals("space-1", payload.todos.single().sharedSpaceId)
+        assertEquals(listOf("space-1"), payload.diaries.single().shared)
+        assertEquals("space-1", payload.schedules.single().sharedSpaceId)
+    }
+
+    @Test
+    fun explicitSharedSpaceIsPreservedOverActiveSharedSpace() {
+        val repository = repository(
+            tempStoreFile(),
+            ids = mutableListOf("local_todo"),
+            activeSharedSpaceId = "space-active",
+        )
+
+        val todo = repository.updateTodo(
+            Todo(
+                title = "Todo",
+                endDate = LocalDate.of(2026, 4, 7),
+                shared = listOf("space-explicit"),
+                sharedSpaceId = "space-explicit",
+            )
+        )
+
+        assertEquals("space-explicit", todo.sharedSpaceId)
+        assertEquals(listOf("space-explicit"), repository.buildSyncPayload().todos.single().shared)
+    }
+
+
+    @Test
     fun syncServerSendsPayloadThroughTransportAndReplacesLocalRecordsOnSuccess() {
         val fakeTransport = FakeCalendarServerTransport(
             response = CalendarDto(
@@ -189,12 +236,14 @@ class CalendarRepositoryTest {
         file: File,
         ids: MutableList<String> = mutableListOf("local_unused"),
         transport: CalendarServerTransport = FakeCalendarServerTransport(),
+        activeSharedSpaceId: String? = null,
     ): CalendarRepositoryImpl {
         return CalendarRepositoryImpl(
             store = CalendarJsonStore(file),
             transport = transport,
             idProvider = { ids.removeAt(0) },
             clock = fixedClock,
+            activeSharedSpaceIdProvider = { activeSharedSpaceId },
         )
     }
 

--- a/android_memorybox/app/src/test/java/com/memorybox/android/canvas/CanvasModelsTest.kt
+++ b/android_memorybox/app/src/test/java/com/memorybox/android/canvas/CanvasModelsTest.kt
@@ -1,0 +1,33 @@
+package com.memorybox.android.canvas
+
+import kotlin.test.assertEquals
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import org.junit.Test
+
+class CanvasModelsTest {
+    private val json = Json { encodeDefaults = true; ignoreUnknownKeys = true }
+
+    @Test
+    fun strokeJsonRoundTripPreservesNormalizedPoints() {
+        val stroke = CanvasStroke(
+            id = "stroke-1",
+            canvasId = "canvas-1",
+            sharedSpaceId = "space-1",
+            authorId = "user-1",
+            sequence = 7,
+            tool = CanvasTool.Pen,
+            colorHex = "#3D2C2E",
+            lineWidth = 6f,
+            points = listOf(CanvasPoint(1.2f, -0.4f, t = 10.0, pressure = 0.8f)),
+        ).normalized()
+
+        val decoded = json.decodeFromString<CanvasStroke>(json.encodeToString(stroke))
+
+        assertEquals(1.0f, decoded.points.single().x)
+        assertEquals(0.0f, decoded.points.single().y)
+        assertEquals(CanvasTool.Pen, decoded.tool)
+        assertEquals("space-1", decoded.sharedSpaceId)
+    }
+}

--- a/android_memorybox/app/src/test/java/com/memorybox/android/canvas/CanvasRepositoryTest.kt
+++ b/android_memorybox/app/src/test/java/com/memorybox/android/canvas/CanvasRepositoryTest.kt
@@ -56,3 +56,41 @@ class CanvasRepositoryTest {
 
     private fun tempFile(): File = kotlin.io.path.createTempDirectory("canvas-repository-test").toFile().resolve("canvas.json")
 }
+
+class CanvasNetworkBoundaryTest {
+    @Test
+    fun networkTransportUsesSharedSpaceCanvasPaths() {
+        val transport = RecordingCanvasTransport()
+        val repository = LocalCanvasRepository(
+            CanvasJsonStore(kotlin.io.path.createTempDirectory("canvas-network-test").toFile().resolve("canvas.json")),
+            transport = transport,
+        )
+
+        repository.fetchRemoteCanvas("space-1")
+        repository.appendRemoteStroke(CanvasStroke("s1", "c1", "space-1", "me", 1, CanvasTool.Pen, "#000000", 4f, emptyList()))
+        repository.fetchRemoteStrokes("space-1", afterSequence = 1)
+        repository.clearRemoteCanvas("space-1")
+        repository.updateRemoteSnapshot(CanvasSnapshot("snap1", "c1", "space-1", 1, width = 800, height = 800))
+        repository.fetchRemoteSnapshot("space-1")
+
+        assertEquals(
+            listOf(
+                CanvasHttpRequest(CanvasHttpMethod.Get, "/shared-spaces/space-1/canvas"),
+                CanvasHttpRequest(CanvasHttpMethod.Post, "/shared-spaces/space-1/canvas/strokes"),
+                CanvasHttpRequest(CanvasHttpMethod.Get, "/shared-spaces/space-1/canvas/strokes?afterSequence=1"),
+                CanvasHttpRequest(CanvasHttpMethod.Post, "/shared-spaces/space-1/canvas/clear"),
+                CanvasHttpRequest(CanvasHttpMethod.Post, "/shared-spaces/space-1/canvas/snapshot"),
+                CanvasHttpRequest(CanvasHttpMethod.Get, "/shared-spaces/space-1/canvas/snapshot"),
+            ),
+            transport.requests,
+        )
+    }
+
+    private class RecordingCanvasTransport : CanvasTransport {
+        val requests = mutableListOf<CanvasHttpRequest>()
+        override fun request(request: CanvasHttpRequest): CanvasHttpResponse {
+            requests += request
+            return CanvasHttpResponse(503, "")
+        }
+    }
+}

--- a/android_memorybox/app/src/test/java/com/memorybox/android/canvas/CanvasRepositoryTest.kt
+++ b/android_memorybox/app/src/test/java/com/memorybox/android/canvas/CanvasRepositoryTest.kt
@@ -1,0 +1,58 @@
+package com.memorybox.android.canvas
+
+import com.memorybox.android.core.network.DataResult
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CanvasRepositoryTest {
+    @Test
+    fun appendPersistsAndFetchAfterSequenceReturnsNewerStrokes() {
+        val repository = LocalCanvasRepository(CanvasJsonStore(tempFile()), idProvider = { "canvas-1" })
+        val first = stroke(sequence = 1)
+        val second = stroke(id = "stroke-2", sequence = 2)
+
+        repository.appendStroke(first)
+        repository.appendStroke(second)
+        val result = repository.fetchStrokes("space-1", afterSequence = 1)
+
+        assertTrue(result is DataResult.Success<*>)
+        assertEquals(listOf(second), (result as DataResult.Success).data)
+    }
+
+    @Test
+    fun clearCanvasRemovesLocalStrokesAndAdvancesCanvas() {
+        val repository = LocalCanvasRepository(CanvasJsonStore(tempFile()), idProvider = { "canvas-1" })
+        repository.appendStroke(stroke(sequence = 1))
+
+        val clear = repository.clearCanvas("space-1")
+        val strokes = repository.fetchStrokes("space-1", afterSequence = null)
+
+        assertTrue(clear is DataResult.Success<*>)
+        assertEquals(0, ((strokes as DataResult.Success).data).size)
+    }
+
+    @Test
+    fun missingSharedSpaceFailsClearly() {
+        val repository = LocalCanvasRepository(CanvasJsonStore(tempFile()))
+        val result = repository.fetchCanvas("")
+
+        assertTrue(result is DataResult.Failure)
+        assertEquals("sharedSpaceId is required", (result as DataResult.Failure).message)
+    }
+
+    private fun stroke(id: String = "stroke-1", sequence: Int) = CanvasStroke(
+        id = id,
+        canvasId = "canvas-1",
+        sharedSpaceId = "space-1",
+        authorId = "me",
+        sequence = sequence,
+        tool = CanvasTool.Pen,
+        colorHex = "#3D2C2E",
+        lineWidth = 4f,
+        points = listOf(CanvasPoint(0.1f, 0.2f)),
+    )
+
+    private fun tempFile(): File = kotlin.io.path.createTempDirectory("canvas-repository-test").toFile().resolve("canvas.json")
+}

--- a/android_memorybox/app/src/test/java/com/memorybox/android/canvas/SnapshotThrottleTest.kt
+++ b/android_memorybox/app/src/test/java/com/memorybox/android/canvas/SnapshotThrottleTest.kt
@@ -1,0 +1,16 @@
+package com.memorybox.android.canvas
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SnapshotThrottleTest {
+    @Test
+    fun allowsFirstStrokeEndThenCoalescesUntilMinimumInterval() {
+        val throttle = SnapshotThrottle(minIntervalMillis = 2_000)
+
+        assertTrue(throttle.shouldUpdate(nowMillis = 1_000))
+        assertFalse(throttle.shouldUpdate(nowMillis = 2_000))
+        assertTrue(throttle.shouldUpdate(nowMillis = 3_000))
+    }
+}

--- a/android_memorybox/app/src/test/java/com/memorybox/android/core/MemoryBoxEndpointsTest.kt
+++ b/android_memorybox/app/src/test/java/com/memorybox/android/core/MemoryBoxEndpointsTest.kt
@@ -29,4 +29,12 @@ class MemoryBoxEndpointsTest {
         assertEquals("/friend/accept/u1", MemoryBoxEndpoints.Friend.accept("u1"))
         assertEquals("/friend/u1", MemoryBoxEndpoints.Friend.friend("u1"))
     }
+
+    @Test
+    fun sharedSpaceEndpointsMatchPairingPlanPaths() {
+        assertEquals("/shared-spaces/active", MemoryBoxEndpoints.SharedSpace.active)
+        assertEquals("/shared-spaces/invites", MemoryBoxEndpoints.SharedSpace.invites)
+        assertEquals("/shared-spaces/invites/ABC123/accept", MemoryBoxEndpoints.SharedSpace.acceptInvite("ABC123"))
+        assertEquals("/shared-spaces/space-1/members/me", MemoryBoxEndpoints.SharedSpace.leave("space-1"))
+    }
 }

--- a/android_memorybox/app/src/test/java/com/memorybox/android/map/TripStoreTest.kt
+++ b/android_memorybox/app/src/test/java/com/memorybox/android/map/TripStoreTest.kt
@@ -57,6 +57,19 @@ class TripStoreTest {
     }
 
     @Test
+    fun upsertAppliesActiveSharedSpaceWhenTripHasNoExplicitSharedSpace() {
+        val file = temporaryFolder.newFile("trips-shared.json")
+        val store = TripStore(file, activeSharedSpaceIdProvider = { "space-1" })
+
+        store.upsert(trip(11110, "jongno.jpg"))
+        store.upsert(trip(26110, "jung.jpg").copy(sharedSpaceId = "space-explicit"))
+
+        assertEquals("space-1", TripStore(file).load(11110)?.sharedSpaceId)
+        assertEquals("space-explicit", TripStore(file).load(26110)?.sharedSpaceId)
+    }
+
+
+    @Test
     fun corruptStoreReadQuarantinesRawFileBeforeReturningEmptyTrips() {
         val file = temporaryFolder.newFile("trips-corrupt.json")
         file.writeText("{not-json")

--- a/android_memorybox/app/src/test/java/com/memorybox/android/pairing/PairingRepositoryTest.kt
+++ b/android_memorybox/app/src/test/java/com/memorybox/android/pairing/PairingRepositoryTest.kt
@@ -1,0 +1,105 @@
+package com.memorybox.android.pairing
+
+import com.memorybox.android.core.network.DataResult
+import com.memorybox.android.friend.FriendHttpMethod
+import com.memorybox.android.friend.FriendHttpRequest
+import com.memorybox.android.friend.FriendHttpResponse
+import com.memorybox.android.friend.FriendTransport
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PairingRepositoryTest {
+    @Test
+    fun networkRepositoryUsesSharedSpaceEndpointPathsAndMethods() = runBlocking {
+        val transport = RecordingPairingTransport(
+            FriendHttpResponse(
+                statusCode = 200,
+                body = """{"success":true,"message":"ok","data":{"id":"space-1","type":"pair","name":"Pair","members":[]}}""",
+            ),
+            FriendHttpResponse(
+                statusCode = 200,
+                body = """{"success":true,"message":"ok","data":{"code":"ABC123","sharedSpaceId":"space-1","inviterId":"me","expiresAt":"2026-05-09T00:00:00Z"}}""",
+            ),
+            FriendHttpResponse(
+                statusCode = 200,
+                body = """{"success":true,"message":"ok","data":{"id":"space-2","type":"pair","members":[{"userId":"partner","name":"Partner","role":"member"}]}}""",
+            ),
+            FriendHttpResponse(
+                statusCode = 200,
+                body = """{"success":true,"message":"ok","data":{"id":"space-2","type":"pair","members":[]}}""",
+            ),
+        )
+        val repository = NetworkPairingRepository(transport)
+
+        repository.fetchActiveSharedSpace()
+        repository.createPairingInvite()
+        repository.acceptPairingInvite("ABC123")
+        repository.leaveSharedSpace("space-2")
+
+        assertEquals(
+            listOf(
+                FriendHttpRequest(FriendHttpMethod.Get, "/shared-spaces/active"),
+                FriendHttpRequest(FriendHttpMethod.Post, "/shared-spaces/invites"),
+                FriendHttpRequest(FriendHttpMethod.Post, "/shared-spaces/invites/ABC123/accept"),
+                FriendHttpRequest(FriendHttpMethod.Delete, "/shared-spaces/space-2/members/me"),
+            ),
+            transport.requests,
+        )
+    }
+
+    @Test
+    fun localRepositoryPersistsAndClearsActiveSharedSpace() = runBlocking {
+        val store = InMemoryActiveSharedSpaceStore()
+        val repository = LocalPairingRepository(
+            userId = "me",
+            store = store,
+            codeProvider = { "LOCAL1" },
+            idProvider = { "space-local" },
+        )
+
+        val invite = repository.createPairingInvite()
+        val accepted = repository.acceptPairingInvite("LOCAL1")
+        val fetched = repository.fetchActiveSharedSpace()
+        val left = repository.leaveSharedSpace("space-local")
+        val fetchedAfterLeave = repository.fetchActiveSharedSpace()
+
+        assertTrue(invite is DataResult.Success<*>)
+        assertEquals("LOCAL1", (invite as DataResult.Success).data.code)
+        assertTrue(accepted is DataResult.Success<*>)
+        assertEquals("space-local", (accepted as DataResult.Success).data.id)
+        assertEquals("space-local", ((fetched as DataResult.Success).data)?.id)
+        assertTrue(left is DataResult.Success<*>)
+        assertNull((fetchedAfterLeave as DataResult.Success).data)
+    }
+
+    private class RecordingPairingTransport(
+        vararg responses: FriendHttpResponse,
+    ) : FriendTransport {
+        private val responseQueue = ArrayDeque(responses.toList())
+        val requests = mutableListOf<FriendHttpRequest>()
+
+        override suspend fun request(request: FriendHttpRequest): FriendHttpResponse {
+            requests += request
+            return responseQueue.removeFirst()
+        }
+    }
+
+    private class InMemoryActiveSharedSpaceStore(
+        initialSharedSpace: SharedSpace? = null,
+    ) : ActiveSharedSpaceStore {
+        private var sharedSpace = initialSharedSpace
+
+        override fun load(): SharedSpace? = sharedSpace
+
+        override fun save(sharedSpace: SharedSpace) {
+            this.sharedSpace = sharedSpace
+        }
+
+        override fun clear() {
+            sharedSpace = null
+        }
+    }
+}

--- a/android_memorybox/app/src/test/java/com/memorybox/android/widget/data/DdayWidgetStoreTest.kt
+++ b/android_memorybox/app/src/test/java/com/memorybox/android/widget/data/DdayWidgetStoreTest.kt
@@ -91,4 +91,14 @@ class DdayWidgetStoreTest {
         assertEquals(false, restored.single().isShowTitle)
         assertEquals(WidgetAlign.TopRight, restored.single().titleAlignment)
     }
+
+    @Test
+    fun upsertAppliesActiveSharedSpaceButSelectionRemainsLocal() {
+        val item = DdayWidgetItem(id = "anniversary", title = "Anniversary")
+
+        val state = DdayWidgetStore.upsert(DdayWidgetStore.State(), item, activeSharedSpaceId = "space-1")
+
+        assertEquals("space-1", state.items.single().sharedSpaceId)
+        assertEquals("anniversary", state.selectedId)
+    }
 }

--- a/docs/checklists/2026-05-08-memorybox-verification-checklist.md
+++ b/docs/checklists/2026-05-08-memorybox-verification-checklist.md
@@ -1,0 +1,339 @@
+# MemoryBox Verification Checklist
+
+Use this checklist to verify the work currently included in PR #13.
+
+PR: https://github.com/jibongPark/ios_coupleapp/pull/13
+Branch: `feat/memorybox-priority-completion`
+
+## 0. Before Testing
+
+- [ ] Open PR #13 and confirm it is still open/mergeable.
+- [ ] Pull latest branch locally.
+- [ ] Confirm current branch is `feat/memorybox-priority-completion`.
+- [ ] Confirm working tree is clean before testing.
+- [ ] Confirm backend base URL is available or note that backend-related checks will be skipped.
+- [ ] Prepare two test accounts: User A and User B.
+- [ ] Prepare at least one iOS device/simulator if available.
+- [ ] Prepare at least one Android device/emulator if available.
+
+## 1. Local Tooling / Build Environment
+
+### iOS
+
+- [ ] macOS environment is available.
+- [ ] Xcode is installed.
+- [ ] Tuist is installed.
+- [ ] Run `tuist generate`.
+- [ ] Open generated workspace/project in Xcode.
+- [ ] Build the main iOS app target.
+- [ ] Run available iOS tests with `tuist test` or Xcode test.
+
+Expected:
+
+- [ ] Project generation succeeds.
+- [ ] App compiles.
+- [ ] Tests pass or failures are documented with logs.
+
+### Android
+
+- [ ] JDK 17 is installed.
+- [ ] `JAVA_HOME` is set.
+- [ ] Android SDK 35 is installed.
+- [ ] Run `cd android_memorybox`.
+- [ ] Run `./gradlew testDebugUnitTest`.
+- [ ] Run `./gradlew assembleDebug`.
+- [ ] Install debug APK on emulator/device.
+
+Expected:
+
+- [ ] Unit tests pass.
+- [ ] Debug APK builds.
+- [ ] App launches successfully.
+
+## 2. Existing Priority Work
+
+### Missing API Base URL Safety
+
+- [ ] Launch iOS app without API base URL configured.
+- [ ] Try login/backend-dependent flows.
+- [ ] Confirm app does not crash.
+- [ ] Confirm user-facing setup/error message appears.
+
+Expected:
+
+- [ ] No `fatalError("URL String not found")` crash.
+- [ ] No force-cast URL crash.
+
+### Settings Entry / Android Polish
+
+- [ ] iOS settings entry appears where expected.
+- [ ] Android settings/user-flow polish is visible.
+- [ ] Empty/loading/error states appear without crashes.
+
+## 3. Pairing / SharedSpace
+
+### Pairing Setup
+
+- [ ] Log in as User A.
+- [ ] Open Friend/Pairing screen.
+- [ ] Confirm not-paired state is shown.
+- [ ] Create pairing invite/code as User A.
+- [ ] Log in as User B on another device/session.
+- [ ] Enter User A's code as User B.
+- [ ] Accept pairing.
+
+Expected:
+
+- [ ] Both users show paired/shared-space state.
+- [ ] Active `sharedSpaceId` is stored locally.
+- [ ] Invalid/expired code shows a clear error.
+- [ ] Missing API base URL does not crash.
+
+### Pairing Removal
+
+- [ ] Use unpair/leave shared space action.
+- [ ] Confirm confirmation dialog/message appears if implemented.
+- [ ] Confirm paired state clears locally.
+- [ ] Confirm future shared writes stop after unpair.
+
+Expected:
+
+- [ ] User is no longer paired.
+- [ ] `activeSharedSpaceId` is cleared.
+- [ ] Existing cached data handling matches expected policy.
+
+## 4. Shared Calendar
+
+### iOS Calendar Sharing
+
+- [ ] Pair User A and User B.
+- [ ] On User A, create a todo.
+- [ ] On User A, create a schedule.
+- [ ] On User A, create a diary entry.
+- [ ] Sync/refresh as User B.
+
+Expected:
+
+- [ ] New records are scoped to the active shared space or existing shared field.
+- [ ] User B can see shared calendar records after sync.
+- [ ] Editing a shared record syncs correctly.
+- [ ] Deleting a shared record syncs correctly.
+
+### Android Calendar Sharing
+
+- [ ] Pair User A and User B.
+- [ ] Create calendar records on Android.
+- [ ] Confirm records store/apply `sharedSpaceId`.
+- [ ] Confirm records can sync or remain queued when backend is unavailable.
+
+Expected:
+
+- [ ] Local records persist.
+- [ ] Shared-space scoping is present.
+- [ ] No crash if backend is unavailable.
+
+## 5. Shared Travel / Map Photos
+
+- [ ] Pair User A and User B.
+- [ ] Open Map/Travel screen.
+- [ ] Select a region.
+- [ ] Add a trip record.
+- [ ] Attach/select an image.
+- [ ] Save trip.
+- [ ] Restart app and confirm trip persists.
+- [ ] Sync/refresh as partner.
+
+Expected:
+
+- [ ] Trip record stores `sharedSpaceId`.
+- [ ] Image is copied/stored safely in app-private storage.
+- [ ] Partner can receive trip metadata when backend supports it.
+- [ ] Shared image display works once backend media upload/download is available.
+
+Backend note:
+
+- [ ] Confirm server media upload/download contract for shared trip photos.
+
+## 6. Shared D-Day / Widget
+
+- [ ] Pair User A and User B.
+- [ ] Create a D-Day item.
+- [ ] Add title/date/image/options if available.
+- [ ] Confirm D-Day item stores `sharedSpaceId`.
+- [ ] Sync/refresh as partner.
+- [ ] Select representative D-Day item for widget.
+- [ ] Confirm widget/home display updates.
+
+Expected:
+
+- [ ] D-Day record data is shareable.
+- [ ] Representative widget selection remains device-local.
+- [ ] Partner sees shared D-Day data after sync.
+- [ ] Widget does not crash if image is missing.
+
+## 7. Live Canvas / 우리 낙서장
+
+### Entry / Pair Requirement
+
+- [ ] Open `우리 낙서장` while not paired.
+- [ ] Confirm pairing-required message appears.
+- [ ] Pair two users.
+- [ ] Reopen `우리 낙서장`.
+
+Expected:
+
+- [ ] Not-paired users cannot publish shared strokes.
+- [ ] Paired users can access canvas.
+
+### Drawing Basics
+
+- [ ] Draw with pen.
+- [ ] Change color.
+- [ ] Change stroke width.
+- [ ] Use eraser.
+- [ ] Clear canvas.
+- [ ] Confirm clear action is protected by confirmation if implemented.
+
+Expected:
+
+- [ ] Strokes render correctly.
+- [ ] Normalized coordinates look correct across screen sizes.
+- [ ] Clear removes or resets canvas locally and sync boundary is called.
+
+### Local Persistence
+
+- [ ] Draw several strokes.
+- [ ] Background/close app.
+- [ ] Relaunch app.
+
+Expected:
+
+- [ ] Last canvas/strokes reload locally.
+- [ ] Latest snapshot metadata/path remains available.
+
+### Partner Sync
+
+- [ ] User A draws a stroke.
+- [ ] User B opens or refreshes canvas.
+- [ ] Confirm User B receives stroke via polling/API boundary or backend sync.
+- [ ] Repeat with User B drawing.
+
+Expected:
+
+- [ ] Strokes are scoped by `sharedSpaceId`.
+- [ ] Sequence/after-sequence fetch does not duplicate strokes.
+- [ ] Offline strokes are queued or preserved locally.
+
+Backend note:
+
+- [ ] Confirm whether backend supports WebSocket/SSE.
+- [ ] If not, confirm polling endpoint behavior.
+
+## 8. Live Canvas Snapshot / Lock Screen
+
+### Snapshot Rendering
+
+- [ ] Draw a stroke.
+- [ ] End stroke.
+- [ ] Confirm snapshot is generated.
+- [ ] Draw multiple strokes quickly.
+- [ ] Confirm throttle/coalescing avoids excessive updates.
+
+Expected:
+
+- [ ] Snapshot image shows latest drawing.
+- [ ] Snapshot updates on stroke end or throttled interval.
+- [ ] App does not attempt high-frequency lock-screen updates per point.
+
+### iOS Lock Screen / WidgetKit Path
+
+- [ ] Confirm App Group configuration is correct.
+- [ ] Confirm latest snapshot is written to widget-accessible storage.
+- [ ] Add/enable Lock Screen widget or supported surface.
+- [ ] Draw in app.
+- [ ] Lock device or view widget surface.
+
+Expected:
+
+- [ ] Latest snapshot appears where iOS allows it.
+- [ ] Widget/lock-screen surface updates within OS limits.
+- [ ] If full target setup is incomplete, required setup is documented.
+
+### Android Notification / Widget Fallback
+
+- [ ] Grant notification permission if required.
+- [ ] Draw in app.
+- [ ] Confirm notification/widget snapshot updates.
+- [ ] Lock device and check lock-screen visibility.
+
+Expected:
+
+- [ ] Android fallback shows latest canvas snapshot where OS permits.
+- [ ] Notification/widget update is throttled.
+- [ ] No crash if notification permission is denied.
+
+## 9. Backend Contract Checklist
+
+Pairing:
+
+- [ ] `GET /shared-spaces/active`
+- [ ] `POST /shared-spaces/invites`
+- [ ] `POST /shared-spaces/invites/{code}/accept`
+- [ ] `DELETE /shared-spaces/{id}/members/me`
+
+Calendar / Shared Data:
+
+- [ ] Decide whether server prefers `sharedSpaceId`, existing `shared` array, or both.
+- [ ] Confirm calendar sync reads/writes paired records correctly.
+- [ ] Confirm trip records can be scoped by shared space.
+- [ ] Confirm D-Day records can be scoped by shared space.
+
+Live Canvas:
+
+- [ ] `GET /shared-spaces/{sharedSpaceId}/canvas`
+- [ ] `POST /shared-spaces/{sharedSpaceId}/canvas/strokes`
+- [ ] `GET /shared-spaces/{sharedSpaceId}/canvas/strokes?afterSequence={sequence}`
+- [ ] `POST /shared-spaces/{sharedSpaceId}/canvas/clear`
+- [ ] `POST /shared-spaces/{sharedSpaceId}/canvas/snapshot`
+- [ ] `GET /shared-spaces/{sharedSpaceId}/canvas/snapshot`
+- [ ] Optional realtime: `WS /shared-spaces/{sharedSpaceId}/canvas/live`
+
+Media:
+
+- [ ] Confirm upload path for trip photos.
+- [ ] Confirm upload path for canvas snapshots if server-rendered or server-hosted.
+- [ ] Confirm auth/permission rules for paired users only.
+
+## 10. Regression Checklist
+
+- [ ] Login still works.
+- [ ] Logout still clears session.
+- [ ] Friend list still works.
+- [ ] Friend request accept/reject/delete still works.
+- [ ] Calendar existing local data remains visible.
+- [ ] Map/trip existing local data remains visible.
+- [ ] D-Day existing local data remains visible.
+- [ ] App handles missing backend config gracefully.
+- [ ] App handles offline mode gracefully.
+- [ ] App does not crash on cold start.
+
+## 11. Final Merge Readiness
+
+- [ ] iOS build passes.
+- [ ] iOS tests pass or known failures are documented.
+- [ ] Android unit tests pass.
+- [ ] Android debug APK builds.
+- [ ] Manual QA critical paths pass.
+- [ ] Backend API gaps are documented or resolved.
+- [ ] PR body reflects Pairing and Live Canvas work.
+- [ ] Screenshots/videos are attached if useful.
+- [ ] Reviewer notes include skipped local verification reasons.
+- [ ] PR remains mergeable.
+
+## Known Current Limitations
+
+- Local OpenClaw environment did not have Java/JAVA_HOME, so Android Gradle verification could not be run here.
+- Local OpenClaw environment did not have Tuist, so iOS project generation/tests could not be run here.
+- True high-frequency lock-screen updates are OS-limited; implementation intentionally uses throttled snapshots.
+- Backend realtime/WebSocket support was not present in the repo; current implementation includes API boundary/local-first fallback.
+- Shared travel photo and canvas snapshot media sync require backend media contract confirmation.

--- a/docs/plans/2026-05-08-memorybox-live-canvas-lockscreen.md
+++ b/docs/plans/2026-05-08-memorybox-live-canvas-lockscreen.md
@@ -1,0 +1,464 @@
+# MemoryBox Live Canvas Lock Screen Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build a paired-user Live Canvas feature where app-level strokes sync between paired users and lock-screen surfaces display a throttled latest snapshot.
+
+**Architecture:** Add shared canvas models/repositories scoped by `sharedSpaceId`, then implement drawing UI, local stroke persistence, snapshot rendering, and platform-specific snapshot display. Start with stroke-end sync and snapshot throttling so the feature works within iOS/Android lock-screen update limits.
+
+**Tech Stack:** Swift, SwiftUI, TCA, Tuist modules, WidgetKit/App Group where available; Kotlin, Jetpack Compose, Kotlin serialization, app-private files, Android widget/notification fallback, JUnit.
+
+---
+
+## Prerequisites
+
+- Work in branch: `feat/memorybox-priority-completion` or a new feature branch from it.
+- Design doc: `docs/superpowers/plans/2026-05-08-memorybox-live-canvas-lockscreen-design.md`
+- Pairing/sharedSpace implementation should exist first.
+- Keep changes small and commit after each task.
+- If local tools are missing, run static verification and document skipped builds/tests.
+
+---
+
+### Task 1: Add Shared Canvas Domain Models
+
+**Files:**
+- Create: `Projects/Domains/CanvasDomain/Sources/CanvasVO.swift`
+- Create: `Projects/Domains/CanvasDomain/Sources/CanvasRepository.swift`
+- Create or modify: `Projects/Domains/CanvasDomain/Project.swift`
+- Create: `android_memorybox/app/src/main/java/com/memorybox/android/canvas/CanvasModels.kt`
+- Test: `android_memorybox/app/src/test/java/com/memorybox/android/canvas/CanvasModelsTest.kt`
+
+**Step 1: Add iOS value objects**
+
+Create models:
+
+```swift
+public struct SharedCanvasVO: Equatable, Sendable {
+    public let id: String
+    public let sharedSpaceId: String
+    public let title: String?
+    public let latestSnapshotVersion: Int
+    public let latestSnapshotUrl: String?
+    public let localSnapshotPath: String?
+}
+
+public struct CanvasStrokeVO: Equatable, Sendable, Identifiable {
+    public let id: String
+    public let canvasId: String
+    public let sharedSpaceId: String
+    public let authorId: String
+    public let sequence: Int
+    public let tool: CanvasTool
+    public let colorHex: String
+    public let lineWidth: Double
+    public let points: [CanvasPointVO]
+}
+
+public enum CanvasTool: String, Equatable, Sendable {
+    case pen
+    case eraser
+}
+
+public struct CanvasPointVO: Equatable, Sendable {
+    public let x: Double
+    public let y: Double
+    public let t: Double?
+    public let pressure: Double?
+}
+
+public struct CanvasSnapshotVO: Equatable, Sendable {
+    public let id: String
+    public let canvasId: String
+    public let sharedSpaceId: String
+    public let version: Int
+    public let imageUrl: String?
+    public let localPath: String?
+    public let width: Int
+    public let height: Int
+}
+```
+
+**Step 2: Add iOS repository protocol**
+
+Add methods:
+
+```swift
+func fetchCanvas(sharedSpaceId: String) -> Effect<DataResult<SharedCanvasVO>>
+func fetchStrokes(sharedSpaceId: String, afterSequence: Int?) -> Effect<DataResult<[CanvasStrokeVO]>>
+func appendStroke(_ stroke: CanvasStrokeVO) -> Effect<DataResult<CanvasStrokeVO>>
+func clearCanvas(sharedSpaceId: String) -> Effect<DataResult<SharedCanvasVO>>
+func updateSnapshot(_ snapshot: CanvasSnapshotVO) -> Effect<DataResult<CanvasSnapshotVO>>
+```
+
+**Step 3: Add Android serializable models**
+
+Create equivalent Kotlin models with normalized points.
+
+**Step 4: Add Android model tests**
+
+Test JSON encode/decode of `CanvasStroke` and normalized point values.
+
+**Step 5: Verification**
+
+Run:
+
+```bash
+grep -RIn "SharedCanvas\|CanvasStroke\|CanvasPoint" Projects android_memorybox/app/src/main/java android_memorybox/app/src/test/java | head -120
+```
+
+**Step 6: Commit**
+
+```bash
+git add Projects/Domains/CanvasDomain android_memorybox/app/src/main/java/com/memorybox/android/canvas android_memorybox/app/src/test/java/com/memorybox/android/canvas
+git commit -m "feat: add live canvas domain models"
+```
+
+---
+
+### Task 2: Add Local Canvas Persistence
+
+**Files:**
+- Create: `Projects/Data/CanvasData/Sources/CanvasRepository.swift`
+- Create: `Projects/Data/CanvasData/Sources/CanvasDTO.swift`
+- Create or modify: `Projects/Data/CanvasData/Project.swift`
+- Create: `android_memorybox/app/src/main/java/com/memorybox/android/canvas/CanvasRepository.kt`
+- Test: `android_memorybox/app/src/test/java/com/memorybox/android/canvas/CanvasRepositoryTest.kt`
+
+**Step 1: Add local-first repository behavior**
+
+Implement local persistence for:
+
+- Active shared canvas metadata
+- Append-only strokes
+- Last synced sequence
+- Latest snapshot metadata
+
+**Step 2: Apply sharedSpaceId requirement**
+
+All canvas records must include `sharedSpaceId`. If missing, return a clear failure result.
+
+**Step 3: Queue offline strokes**
+
+Store strokes locally even if network sync is unavailable. Mark as pending if needed.
+
+**Step 4: Add tests**
+
+Test:
+
+- Append stroke persists.
+- Fetch after sequence returns newer strokes only.
+- Clear canvas removes local strokes or marks clear event.
+- Missing sharedSpaceId fails.
+
+**Step 5: Commit**
+
+```bash
+git add Projects/Data/CanvasData android_memorybox/app/src/main/java/com/memorybox/android/canvas android_memorybox/app/src/test/java/com/memorybox/android/canvas
+git commit -m "feat: add local live canvas persistence"
+```
+
+---
+
+### Task 3: Add Snapshot Rendering And Throttling
+
+**Files:**
+- Create: `Projects/CoreKit/Core/Sources/CanvasSnapshotRenderer.swift`
+- Create: `Projects/CoreKit/Core/Sources/ThrottledSnapshotUpdater.swift`
+- Create: `android_memorybox/app/src/main/java/com/memorybox/android/canvas/CanvasSnapshotRenderer.kt`
+- Create: `android_memorybox/app/src/main/java/com/memorybox/android/canvas/SnapshotThrottle.kt`
+- Test: matching unit tests where tooling supports it
+
+**Step 1: Implement normalized stroke rendering**
+
+Render strokes to bitmap/image using normalized coordinates. MVP can use a fixed target size such as 600x600 or 800x800.
+
+**Step 2: Implement throttle policy**
+
+Rules:
+
+- Update on stroke end.
+- Coalesce rapid updates.
+- Minimum interval: 1-3 seconds.
+
+**Step 3: Store latest snapshot path**
+
+Save generated image path in local canvas repository.
+
+**Step 4: Tests/static checks**
+
+Test throttle logic separately from platform rendering where possible.
+
+**Step 5: Commit**
+
+```bash
+git add Projects/CoreKit/Core/Sources android_memorybox/app/src/main/java/com/memorybox/android/canvas android_memorybox/app/src/test/java/com/memorybox/android/canvas
+git commit -m "feat: render throttled live canvas snapshots"
+```
+
+---
+
+### Task 4: Add iOS Live Canvas Feature UI
+
+**Files:**
+- Create: `Projects/Features/CanvasFeature/Project.swift`
+- Create: `Projects/Features/CanvasFeature/Sources/CanvasReducer.swift`
+- Create: `Projects/Features/CanvasFeature/Sources/CanvasView.swift`
+- Create: `Projects/Features/CanvasFeature/Interface/Sources/CanvasInterface.swift`
+- Test: `Projects/Features/CanvasFeature/Tests/Sources/CanvasReducerTests.swift`
+- Modify: `Projects/App/Main/Sources/AppView.swift`
+
+**Step 1: Create feature module**
+
+Follow existing TCA feature structure.
+
+**Step 2: Add reducer state/actions**
+
+State:
+
+- `activeSharedSpaceId`
+- `canvas`
+- `strokes`
+- `currentStroke`
+- `selectedTool`
+- `selectedColorHex`
+- `lineWidth`
+- `errorMessage`
+
+Actions:
+
+- `onAppear`
+- `startStroke`
+- `appendPoint`
+- `endStroke`
+- `clearTapped`
+- `didLoadCanvas`
+- `didAppendStroke`
+- `didUpdateSnapshot`
+
+**Step 3: Add SwiftUI drawing surface**
+
+Use `DragGesture` to collect normalized points.
+
+**Step 4: Block unpaired users**
+
+If no active shared space exists, show pairing CTA/copy.
+
+**Step 5: Add navigation entry**
+
+Add side menu or tab entry: `우리 낙서장`.
+
+**Step 6: Commit**
+
+```bash
+git add Projects/Features/CanvasFeature Projects/App/Main/Sources/AppView.swift
+git commit -m "feat(ios): add live canvas feature screen"
+```
+
+---
+
+### Task 5: Add Android Live Canvas Screen
+
+**Files:**
+- Create: `android_memorybox/app/src/main/java/com/memorybox/android/canvas/CanvasScreen.kt`
+- Modify: `android_memorybox/app/src/main/java/com/memorybox/android/ui/MemoryBoxApp.kt`
+- Test: `android_memorybox/app/src/test/java/com/memorybox/android/canvas/CanvasRepositoryTest.kt`
+
+**Step 1: Add Compose canvas**
+
+Use `Canvas` and pointer input to collect normalized stroke points.
+
+**Step 2: Add tools**
+
+Pen, eraser, color, width, clear.
+
+**Step 3: Integrate repository**
+
+On stroke end:
+
+- Persist stroke.
+- Trigger throttled snapshot update.
+- Queue/sync remote if network exists.
+
+**Step 4: Block unpaired users**
+
+Show pairing-required message if no active shared space.
+
+**Step 5: Add navigation entry**
+
+Add `우리 낙서장` to existing Android navigation.
+
+**Step 6: Commit**
+
+```bash
+git add android_memorybox/app/src/main/java/com/memorybox/android/canvas android_memorybox/app/src/main/java/com/memorybox/android/ui/MemoryBoxApp.kt
+git commit -m "feat(android): add live canvas screen"
+```
+
+---
+
+### Task 6: Add Network API Boundary For Canvas Sync
+
+**Files:**
+- Create or modify: `Projects/Data/CanvasData/Sources/Network/CanvasAPI.swift`
+- Modify: `Projects/Data/CanvasData/Sources/CanvasRepository.swift`
+- Modify: `android_memorybox/app/src/main/java/com/memorybox/android/canvas/CanvasRepository.kt`
+- Tests: API path tests where possible
+
+**Step 1: Add routes**
+
+Routes:
+
+```text
+GET /shared-spaces/{sharedSpaceId}/canvas
+POST /shared-spaces/{sharedSpaceId}/canvas/strokes
+GET /shared-spaces/{sharedSpaceId}/canvas/strokes?afterSequence={sequence}
+POST /shared-spaces/{sharedSpaceId}/canvas/clear
+POST /shared-spaces/{sharedSpaceId}/canvas/snapshot
+GET /shared-spaces/{sharedSpaceId}/canvas/snapshot
+```
+
+**Step 2: Implement fallback behavior**
+
+If backend base URL is missing, local canvas still works and remote sync returns non-crashing failure.
+
+**Step 3: Add polling MVP**
+
+If WebSocket is unavailable, add a simple fetch-after-sequence method callable on appear/foreground.
+
+**Step 4: Commit**
+
+```bash
+git add Projects/Data/CanvasData android_memorybox/app/src/main/java/com/memorybox/android/canvas android_memorybox/app/src/test/java/com/memorybox/android/canvas
+git commit -m "feat: add live canvas sync API boundary"
+```
+
+---
+
+### Task 7: Add iOS Lock Screen Snapshot Surface
+
+**Files:**
+- Modify or create Widget-related iOS target files according to current project structure
+- Modify: `Projects/Data/CanvasData/Sources/CanvasRepository.swift`
+- Modify docs if target setup requires manual config
+
+**Step 1: Use App Group snapshot path**
+
+Write latest rendered snapshot to a path accessible by widget/live activity.
+
+**Step 2: Add WidgetKit or Live Activity surface**
+
+Recommended MVP:
+
+- If WidgetKit target exists, extend it to show latest canvas snapshot.
+- If no widget target is practical in this repo, document the required target and provide repository snapshot writer first.
+
+**Step 3: Trigger reload conservatively**
+
+Use throttled update calls only.
+
+**Step 4: Commit**
+
+```bash
+git add Projects docs
+git commit -m "feat(ios): add live canvas lock screen snapshot support"
+```
+
+---
+
+### Task 8: Add Android Snapshot Notification/Widget Surface
+
+**Files:**
+- Create: `android_memorybox/app/src/main/java/com/memorybox/android/canvas/CanvasSnapshotNotifier.kt`
+- Modify existing widget files if suitable
+- Modify: `android_memorybox/app/src/main/AndroidManifest.xml` if permissions/services are needed
+
+**Step 1: Add latest snapshot display surface**
+
+Recommended MVP:
+
+- Lock-screen visible notification with latest snapshot where OS permits.
+- Home widget fallback if notification lock screen visibility is limited.
+
+**Step 2: Keep updates throttled**
+
+Do not notify on every point. Update only after throttle/stroke end.
+
+**Step 3: Commit**
+
+```bash
+git add android_memorybox/app/src/main
+git commit -m "feat(android): add live canvas snapshot notification"
+```
+
+---
+
+### Task 9: Documentation And Verification
+
+**Files:**
+- Modify: `android_memorybox/README.md`
+- Create or modify: `docs/superpowers/plans/2026-05-08-memorybox-live-canvas-lockscreen-design.md`
+- Optional: PR body update
+
+**Step 1: Update README/manual QA**
+
+Add Live Canvas setup and QA:
+
+- Pair two users.
+- Draw in app.
+- Partner sees app update.
+- Snapshot appears on lock-screen surface/fallback.
+- Offline queue behavior.
+- Clear canvas.
+
+**Step 2: Run available verification**
+
+Run:
+
+```bash
+grep -RIn "Live Canvas\|우리 낙서장\|CanvasStroke\|CanvasSnapshot" Projects android_memorybox docs | head -200
+git status --short
+```
+
+If available:
+
+```bash
+cd android_memorybox
+./gradlew testDebugUnitTest
+./gradlew assembleDebug
+```
+
+If available:
+
+```bash
+tuist generate
+tuist test
+```
+
+**Step 3: Commit docs**
+
+```bash
+git add android_memorybox/README.md docs
+git commit -m "docs: document live canvas verification"
+```
+
+**Step 4: Push**
+
+```bash
+git push origin feat-memorybox-priority-completion
+```
+
+---
+
+## Completion Criteria
+
+- Live Canvas design and implementation plan are documented.
+- Shared canvas domain models exist on iOS and Android.
+- Local stroke persistence exists.
+- Drawing screen exists on iOS and Android.
+- Stroke-end sync API boundary exists.
+- Latest snapshot rendering and throttling exist.
+- iOS and Android have a first lock-screen/fallback snapshot surface or documented target limitation.
+- Not-paired state blocks publishing and points users to pairing.
+- Manual QA checklist is updated.
+- PR remains mergeable and working tree is clean.

--- a/docs/plans/2026-05-08-memorybox-pairing-shared-space.md
+++ b/docs/plans/2026-05-08-memorybox-pairing-shared-space.md
@@ -1,0 +1,503 @@
+# MemoryBox Pairing Shared Space Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build a 1:1 pairing feature backed by a future-proof `sharedSpaceId` model so paired users can share calendar, travel, and D-Day data.
+
+**Architecture:** Add pairing/shared-space domain models and local active pairing state first, then wire iOS and Android UI/repositories around that state. Calendar sharing should be connected first because iOS already has `shared` fields; trip and D-Day sharing should add `sharedSpaceId` in local models and sync boundaries without forcing a backend contract rewrite.
+
+**Tech Stack:** Swift, TCA, Tuist modules, Moya, Realm; Kotlin, Jetpack Compose, Kotlin serialization, app-private persistence, JUnit.
+
+---
+
+## Prerequisites
+
+- Work in branch: `feat/memorybox-priority-completion`
+- Design doc: `docs/superpowers/plans/2026-05-08-memorybox-pairing-design.md`
+- Keep changes small and commit after each task.
+- If local tools are missing, still run grep/static checks and document skipped verification.
+
+---
+
+### Task 1: Add iOS SharedSpace Domain Models
+
+**Files:**
+- Create: `Projects/Domains/FriendDomain/Sources/SharedSpaceVO.swift`
+- Modify: `Projects/Domains/FriendDomain/Sources/FriendRepository.swift`
+- Test: `Projects/Features/FriendFeature/Tests/Sources/FriendReducerTests.swift`
+
+**Step 1: Create value objects**
+
+Add:
+
+```swift
+import Foundation
+
+public struct SharedSpaceVO: Equatable, Sendable {
+    public let id: String
+    public let type: SharedSpaceType
+    public let name: String?
+    public let members: [SharedSpaceMemberVO]
+    public let createdAt: Date?
+    public let updatedAt: Date?
+
+    public init(
+        id: String,
+        type: SharedSpaceType = .pair,
+        name: String? = nil,
+        members: [SharedSpaceMemberVO] = [],
+        createdAt: Date? = nil,
+        updatedAt: Date? = nil
+    ) {
+        self.id = id
+        self.type = type
+        self.name = name
+        self.members = members
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+}
+
+public enum SharedSpaceType: String, Equatable, Sendable {
+    case pair
+}
+
+public struct SharedSpaceMemberVO: Equatable, Sendable {
+    public let userId: String
+    public let name: String
+    public let role: SharedSpaceMemberRole
+
+    public init(userId: String, name: String, role: SharedSpaceMemberRole = .member) {
+        self.userId = userId
+        self.name = name
+        self.role = role
+    }
+}
+
+public enum SharedSpaceMemberRole: String, Equatable, Sendable {
+    case owner
+    case member
+}
+
+public struct PairingInviteVO: Equatable, Sendable {
+    public let code: String
+    public let sharedSpaceId: String?
+    public let inviterId: String
+    public let expiresAt: Date?
+
+    public init(code: String, sharedSpaceId: String? = nil, inviterId: String, expiresAt: Date? = nil) {
+        self.code = code
+        self.sharedSpaceId = sharedSpaceId
+        self.inviterId = inviterId
+        self.expiresAt = expiresAt
+    }
+}
+```
+
+**Step 2: Extend repository protocol**
+
+In `FriendRepository.swift`, add methods:
+
+```swift
+func fetchActiveSharedSpace() -> Effect<DataResult<SharedSpaceVO?>>
+func createPairingInvite() -> Effect<DataResult<PairingInviteVO>>
+func acceptPairingInvite(_ code: String) -> Effect<DataResult<SharedSpaceVO>>
+func leaveSharedSpace(_ id: String) -> Effect<DataResult<SharedSpaceVO>>
+```
+
+**Step 3: Run a compile-oriented check**
+
+Run:
+
+```bash
+grep -RIn "SharedSpaceVO\|PairingInviteVO" Projects/Domains/FriendDomain/Sources
+```
+
+Expected: new types and protocol methods are present.
+
+**Step 4: Commit**
+
+```bash
+git add Projects/Domains/FriendDomain/Sources
+git commit -m "feat(ios): add shared space domain models"
+```
+
+---
+
+### Task 2: Add iOS FriendData API And Local Active Pairing State
+
+**Files:**
+- Modify: `Projects/Data/FriendData/Sources/Network/FriendAPI.swift`
+- Modify: `Projects/Data/FriendData/Sources/FriendDTO.swift`
+- Modify: `Projects/Data/FriendData/Sources/FriendRepository.swift`
+- Test: `Projects/Features/FriendFeature/Tests/Sources/FriendReducerTests.swift`
+
+**Step 1: Add DTOs**
+
+Add `SharedSpaceDTO`, `SharedSpaceMemberDTO`, and `PairingInviteDTO` with fields matching the VO names. Keep dates optional if backend format is uncertain.
+
+**Step 2: Add API cases**
+
+Add cases:
+
+```swift
+case activeSharedSpace
+case createPairingInvite
+case acceptPairingInvite(code: String)
+case leaveSharedSpace(id: String)
+```
+
+Suggested paths:
+
+```swift
+/shared-spaces/active
+/shared-spaces/invites
+/shared-spaces/invites/{code}/accept
+/shared-spaces/{id}/members/me
+```
+
+**Step 3: Implement repository methods**
+
+Implement methods added in Task 1. Also store active shared space ID locally:
+
+```swift
+ConfigManager.shared.set("activeSharedSpaceId", sharedSpace.id)
+```
+
+On leave/unpair, clear:
+
+```swift
+ConfigManager.shared.set("activeSharedSpaceId", "")
+```
+
+**Step 4: Verify no crash on missing API base URL**
+
+Run:
+
+```bash
+grep -RIn "missingAPIBaseURLMessage\|hasValidAPIBaseURL" Projects/Data/FriendData/Sources
+```
+
+Expected: new methods guard missing base URL like existing friend methods.
+
+**Step 5: Commit**
+
+```bash
+git add Projects/Data/FriendData/Sources
+git commit -m "feat(ios): add shared space friend data APIs"
+```
+
+---
+
+### Task 3: Add iOS Pairing UI State To FriendFeature
+
+**Files:**
+- Modify: `Projects/Features/FriendFeature/Sources/FriendView.swift`
+- Test: `Projects/Features/FriendFeature/Tests/Sources/FriendReducerTests.swift`
+
+**Step 1: Add reducer state**
+
+Add to `FriendReducer.State`:
+
+```swift
+var activeSharedSpace: SharedSpaceVO?
+var pairingInvite: PairingInviteVO?
+var pairingCode: String = ""
+var isPairingLoading: Bool = false
+```
+
+**Step 2: Add actions**
+
+Add:
+
+```swift
+case fetchActiveSharedSpace
+case didFetchActiveSharedSpace(SharedSpaceVO?)
+case createPairingInvite
+case didCreatePairingInvite(PairingInviteVO)
+case pairingCodeChanged(String)
+case acceptPairingInvite
+case didAcceptPairingInvite(SharedSpaceVO)
+case leaveSharedSpace
+case didLeaveSharedSpace
+```
+
+**Step 3: Add reducer behavior**
+
+- `onAppear` should also send `.fetchActiveSharedSpace`.
+- `createPairingInvite` calls repository.
+- `acceptPairingInvite` calls repository with `state.pairingCode`.
+- `leaveSharedSpace` calls repository for `state.activeSharedSpace?.id` and clears state.
+
+**Step 4: Add tests**
+
+Add tests for:
+
+- `didFetchActiveSharedSpace` stores shared space
+- `didCreatePairingInvite` stores invite
+- `pairingCodeChanged` updates input
+- `didAcceptPairingInvite` stores shared space and clears code
+- `didLeaveSharedSpace` clears shared space
+
+**Step 5: Add UI section**
+
+In `FriendView`, add a section above friend list:
+
+- Not paired: show invite code creation button and code input
+- Paired: show partner/shared space info and unpair button
+- Keep copy-my-id existing behavior
+
+**Step 6: Commit**
+
+```bash
+git add Projects/Features/FriendFeature/Sources/FriendView.swift Projects/Features/FriendFeature/Tests/Sources/FriendReducerTests.swift
+git commit -m "feat(ios): add pairing controls to friend feature"
+```
+
+---
+
+### Task 4: Wire iOS Calendar Writes To Active SharedSpace
+
+**Files:**
+- Modify: `Projects/Data/CalendarData/Sources/CalendarRepository.swift`
+- Modify: `Projects/Data/CalendarData/Sources/Network/CalendarAPI.swift`
+- Test: `Projects/Domains/CalendarDomain/Tests/Sources/CalendarDomainTests.swift`
+
+**Step 1: Add helper**
+
+In `CalendarRepository.swift`, add:
+
+```swift
+private var activeSharedSpaceId: String? {
+    let id: String? = ConfigManager.shared.get("activeSharedSpaceId")
+    return id?.isEmpty == false ? id : nil
+}
+```
+
+**Step 2: Apply default sharing on create/update**
+
+When creating/updating todo, schedule, and diary, if the VO's `shared` is empty and active shared space exists, include that ID in the API payload and local persisted `shared` field.
+
+Use conservative logic:
+
+```swift
+let shared = item.shared.isEmpty ? activeSharedSpaceId.map { [$0] } ?? [] : item.shared
+```
+
+**Step 3: Preserve private future path**
+
+Do not force-share if an item already has explicit `shared` values. Do not add a UI privacy toggle in this task.
+
+**Step 4: Static verification**
+
+Run:
+
+```bash
+grep -RIn "activeSharedSpaceId\|shared" Projects/Data/CalendarData/Sources/CalendarRepository.swift
+```
+
+Expected: create/update paths reference active shared space.
+
+**Step 5: Commit**
+
+```bash
+git add Projects/Data/CalendarData/Sources
+git commit -m "feat(ios): scope calendar sharing to active pair"
+```
+
+---
+
+### Task 5: Add Android Pairing Models And Repository
+
+**Files:**
+- Create: `android_memorybox/app/src/main/java/com/memorybox/android/pairing/PairingModels.kt`
+- Create: `android_memorybox/app/src/main/java/com/memorybox/android/pairing/PairingRepository.kt`
+- Test: `android_memorybox/app/src/test/java/com/memorybox/android/pairing/PairingRepositoryTest.kt`
+
+**Step 1: Add serializable models**
+
+Create Kotlin models equivalent to iOS:
+
+```kotlin
+@Serializable
+data class SharedSpace(
+    val id: String,
+    val type: String = "pair",
+    val name: String? = null,
+    val members: List<SharedSpaceMember> = emptyList(),
+)
+
+@Serializable
+data class SharedSpaceMember(
+    val userId: String,
+    val name: String,
+    val role: String = "member",
+)
+
+@Serializable
+data class PairingInvite(
+    val code: String,
+    val sharedSpaceId: String? = null,
+    val inviterId: String,
+    val expiresAt: String? = null,
+)
+```
+
+**Step 2: Add repository interface**
+
+Add methods:
+
+```kotlin
+suspend fun fetchActiveSharedSpace(): DataResult<SharedSpace?>
+suspend fun createPairingInvite(): DataResult<PairingInvite>
+suspend fun acceptPairingInvite(code: String): DataResult<SharedSpace>
+suspend fun leaveSharedSpace(id: String): DataResult<SharedSpace>
+```
+
+**Step 3: Add local repository**
+
+Persist active shared space to app-private JSON or SharedPreferences, following existing Android persistence style.
+
+**Step 4: Add network repository**
+
+Use the same lightweight transport pattern as `FriendRepository.kt`.
+
+**Step 5: Add tests**
+
+Test endpoint paths and local persistence.
+
+**Step 6: Commit**
+
+```bash
+git add android_memorybox/app/src/main/java/com/memorybox/android/pairing android_memorybox/app/src/test/java/com/memorybox/android/pairing
+git commit -m "feat(android): add pairing repository"
+```
+
+---
+
+### Task 6: Add Android Pairing Screen
+
+**Files:**
+- Create: `android_memorybox/app/src/main/java/com/memorybox/android/pairing/PairingScreen.kt`
+- Modify: `android_memorybox/app/src/main/java/com/memorybox/android/ui/MemoryBoxApp.kt`
+- Test: `android_memorybox/app/src/test/java/com/memorybox/android/pairing/PairingRepositoryTest.kt`
+
+**Step 1: Create screen**
+
+Compose UI should mirror iOS states:
+
+- Not paired: create invite, enter code, accept
+- Paired: show partner/member and unpair button
+- Error: show message
+
+**Step 2: Add navigation entry**
+
+Add a Settings/Friend side-menu entry named `페어링` or include the Pairing section inside Friend screen.
+
+Recommended first pass: include it in Friend screen to avoid adding another navigation tab.
+
+**Step 3: Wire repository state**
+
+Use `remember` state and coroutine actions, matching existing `FriendScreen.kt` style.
+
+**Step 4: Commit**
+
+```bash
+git add android_memorybox/app/src/main/java/com/memorybox/android/pairing android_memorybox/app/src/main/java/com/memorybox/android/ui/MemoryBoxApp.kt
+git commit -m "feat(android): add pairing screen"
+```
+
+---
+
+### Task 7: Add sharedSpaceId To Android Calendar, Map, And D-Day Models
+
+**Files:**
+- Modify files under: `android_memorybox/app/src/main/java/com/memorybox/android/calendar/`
+- Modify files under: `android_memorybox/app/src/main/java/com/memorybox/android/map/`
+- Modify files under: `android_memorybox/app/src/main/java/com/memorybox/android/widget/`
+- Tests under matching `android_memorybox/app/src/test/java/com/memorybox/android/*/`
+
+**Step 1: Add field**
+
+Add nullable `sharedSpaceId: String? = null` to local records where user-created shared data is stored.
+
+**Step 2: Read active pairing state**
+
+Where repositories create new records, apply active shared space if present.
+
+**Step 3: Avoid widget device preference sharing**
+
+D-Day record data can be shared. Selected home widget item remains device-local.
+
+**Step 4: Add tests**
+
+Add tests that creating calendar/trip/D-Day records while paired writes `sharedSpaceId`.
+
+**Step 5: Commit**
+
+```bash
+git add android_memorybox/app/src/main/java/com/memorybox/android android_memorybox/app/src/test/java/com/memorybox/android
+git commit -m "feat(android): scope shared data to active pair"
+```
+
+---
+
+### Task 8: Documentation And Verification
+
+**Files:**
+- Modify: `android_memorybox/README.md`
+- Modify or create: `docs/superpowers/plans/2026-05-08-memorybox-pairing-design.md`
+- Optional: PR body update via `gh pr edit`
+
+**Step 1: Update docs**
+
+Document pairing behavior, manual QA, and backend questions.
+
+**Step 2: Run available verification**
+
+Run:
+
+```bash
+grep -RIn "SharedSpace\|sharedSpaceId\|Pairing" Projects android_memorybox | head -200
+git status --short
+```
+
+If tools are available, also run:
+
+```bash
+cd android_memorybox
+./gradlew testDebugUnitTest
+./gradlew assembleDebug
+```
+
+For iOS, if tools are available:
+
+```bash
+tuist generate
+tuist test
+```
+
+**Step 3: Commit docs**
+
+```bash
+git add android_memorybox/README.md docs
+git commit -m "docs: document memorybox pairing verification"
+```
+
+**Step 4: Push**
+
+```bash
+git push origin feat/memorybox-priority-completion
+```
+
+---
+
+## Completion Criteria
+
+- Pairing/shared-space design is documented.
+- iOS has shared-space domain/data/reducer/UI state.
+- Android has pairing models/repository/screen.
+- Calendar records are scoped to active pair.
+- Android calendar/map/D-Day records can store `sharedSpaceId`.
+- Missing backend/tooling limitations are documented clearly.
+- PR remains mergeable and working tree is clean.

--- a/docs/superpowers/plans/2026-05-08-memorybox-live-canvas-lockscreen-design.md
+++ b/docs/superpowers/plans/2026-05-08-memorybox-live-canvas-lockscreen-design.md
@@ -1,0 +1,301 @@
+# MemoryBox Live Canvas / Lock Screen Snapshot Design
+
+## Goal
+
+Add a paired-user drawing and handwriting feature where users can draw or write in the app and share the result with their paired partner. The app should sync strokes in near real time, while each partner's lock screen displays an updated snapshot of the shared canvas within OS limits.
+
+## Recommended Direction
+
+Use a two-layer model:
+
+1. **Live Canvas inside the app**
+   - Sync strokes at stroke/event level.
+   - Partner can see drawing updates quickly while the app is open.
+   - Preserve vector stroke data so the canvas can be replayed, edited, or re-rendered.
+
+2. **Lock Screen Snapshot**
+   - Render the latest canvas to an image snapshot.
+   - Update lock screen presentation on a throttled cadence, such as every 1-3 seconds or on stroke end.
+   - Use the best available platform-specific lock-screen surface.
+
+This avoids promising impossible high-frequency lock screen updates while still delivering the core emotional experience: a partner's drawing or note appears on the other person's screen.
+
+## Platform Constraints
+
+### iOS
+
+- Lock Screen Widgets are not intended for high-frequency real-time updates.
+- WidgetKit has refresh limits and timeline behavior.
+- Live Activities can appear on the Lock Screen and Dynamic Island, but still have update frequency, payload, and system policy limits.
+- Recommended first implementation:
+  - App canvas syncs strokes in near real time.
+  - A canvas snapshot is written into an App Group container.
+  - A WidgetKit Lock Screen widget or Live Activity displays the latest snapshot.
+  - Use throttling to avoid excessive updates.
+
+### Android
+
+- Modern Android has limited general-purpose lock screen widget support.
+- Lock-screen visible notifications are more reliable than true arbitrary lock screen widgets.
+- Home screen widgets can be supported as a fallback.
+- Recommended first implementation:
+  - App canvas syncs strokes in near real time.
+  - A foreground/ongoing or high-visibility notification can display latest snapshot where allowed.
+  - Existing widget infrastructure can be extended for home screen snapshot display.
+
+## User Experience
+
+### Entry Point
+
+Add a new feature entry point such as:
+
+- `Live Canvas`
+- `우리 낙서장`
+- `잠금화면 낙서`
+
+Recommended Korean label: `우리 낙서장`.
+
+### Not Paired
+
+If the user is not paired:
+
+- Explain that the feature requires pairing.
+- Show a button/link to the Pairing screen.
+- Do not allow publishing strokes to shared sync.
+
+### Paired
+
+If paired:
+
+- Show a blank or last saved shared canvas.
+- Tools:
+  - Pen
+  - Eraser
+  - Color selection
+  - Stroke width selection
+  - Clear canvas with confirmation
+- User can draw or handwrite.
+- Partner receives strokes in near real time when online.
+- Lock screen snapshot updates after stroke end or throttled interval.
+
+### Lock Screen Setup
+
+Show setup instructions in-app:
+
+- iOS: enable Lock Screen widget or Live Activity if available.
+- Android: enable notification/widget display depending on implementation.
+
+## Data Model
+
+### SharedCanvas
+
+```text
+SharedCanvas
+- id: String
+- sharedSpaceId: String
+- title: String?
+- latestSnapshotVersion: Int
+- latestSnapshotUrl: String?
+- localSnapshotPath: String?
+- createdAt: Date
+- updatedAt: Date
+```
+
+### CanvasStroke
+
+```text
+CanvasStroke
+- id: String
+- canvasId: String
+- sharedSpaceId: String
+- authorId: String
+- sequence: Int
+- tool: pen | eraser
+- colorHex: String
+- lineWidth: Double
+- points: [CanvasPoint]
+- createdAt: Date
+```
+
+### CanvasPoint
+
+```text
+CanvasPoint
+- x: Double
+- y: Double
+- t: Double?
+- pressure: Double?
+```
+
+Coordinates should be normalized from 0.0 to 1.0 so strokes can render correctly across different screen/widget sizes.
+
+### CanvasSnapshot
+
+```text
+CanvasSnapshot
+- id: String
+- canvasId: String
+- sharedSpaceId: String
+- version: Int
+- imageUrl: String?
+- localPath: String?
+- width: Int
+- height: Int
+- createdAt: Date
+```
+
+## Sync Model
+
+### App-Level Stroke Sync
+
+Preferred realtime transport:
+
+- WebSocket if backend supports it.
+- SSE as a fallback.
+- Polling as MVP fallback if no realtime channel exists.
+
+Events:
+
+```text
+canvas.stroke.started
+canvas.stroke.updated
+canvas.stroke.ended
+canvas.cleared
+canvas.snapshot.updated
+```
+
+For MVP, only `stroke.ended` is required for network persistence. During active drawing, local UI can update immediately and remote can receive either batched points or final stroke.
+
+### Lock Screen Snapshot Sync
+
+Snapshot update policy:
+
+- Render locally after stroke end.
+- Throttle lock screen updates to at most once every 1-3 seconds.
+- If multiple strokes occur quickly, coalesce them into one snapshot update.
+- Store latest snapshot for widget/notification rendering.
+
+## API Shape
+
+Exact backend routes can be adjusted, but the app should expect capabilities like:
+
+```text
+GET    /shared-spaces/{sharedSpaceId}/canvas
+POST   /shared-spaces/{sharedSpaceId}/canvas/strokes
+GET    /shared-spaces/{sharedSpaceId}/canvas/strokes?afterSequence={sequence}
+POST   /shared-spaces/{sharedSpaceId}/canvas/clear
+POST   /shared-spaces/{sharedSpaceId}/canvas/snapshot
+GET    /shared-spaces/{sharedSpaceId}/canvas/snapshot
+```
+
+If realtime is available:
+
+```text
+WS /shared-spaces/{sharedSpaceId}/canvas/live
+```
+
+## Local Persistence
+
+### iOS
+
+- Store stroke data in a local repository or Realm-backed model.
+- Store latest snapshot image in App Group container for widget access.
+- Keep current drawing state recoverable across app restart.
+
+### Android
+
+- Store strokes and snapshot metadata in app-private JSON or existing persistence style.
+- Store latest snapshot bitmap in app-private files.
+- Home widget/notification reads from local snapshot path.
+
+## Snapshot Rendering
+
+Render vector strokes into a bitmap:
+
+- Use normalized canvas points.
+- Render at target aspect ratio for lock screen/widget.
+- Support light/dark background later.
+- MVP background: MemoryBox beige or transparent/white depending on widget surface.
+
+## Error Handling
+
+- Not paired: block shared sync and show pairing CTA.
+- Offline: allow local drawing, queue strokes for later sync.
+- Sync conflict: order by `sequence` and `createdAt`; prefer append-only strokes.
+- Clear canvas: require confirmation and sync `canvas.cleared` event.
+- Snapshot update failure: keep showing last successful snapshot.
+
+## Privacy / Safety
+
+- Only paired users in the active `sharedSpaceId` can read/write canvas data.
+- Unpairing should stop future sync immediately.
+- Decide whether old canvas remains visible after unpairing. Recommended MVP: keep local cached image but stop remote updates and hide shared controls.
+
+## MVP Scope
+
+In scope:
+
+- One shared canvas per active pair.
+- Pen, eraser, color, line width.
+- Stroke-end persistence and partner sync.
+- Throttled snapshot rendering.
+- iOS widget/live-activity-capable snapshot storage.
+- Android notification/widget snapshot storage.
+- Documentation and manual QA.
+
+Out of scope for MVP:
+
+- Multi-page canvases.
+- Rich typed text blocks.
+- Stickers/images.
+- Infinite canvas.
+- Pixel-perfect lock screen UI across all devices.
+- Guaranteed per-point lock screen updates.
+
+## Implementation Phases
+
+1. Add shared canvas domain models and repository contracts.
+2. Add local stroke persistence and snapshot rendering.
+3. Add drawing screen using sharedSpaceId.
+4. Add network API boundary for strokes/snapshot.
+5. Add iOS lock screen snapshot surface.
+6. Add Android snapshot notification/widget surface.
+7. Add tests and manual QA documentation.
+
+## Verification Plan
+
+### Unit Tests
+
+- Stroke model encoding/decoding.
+- Normalized point rendering input.
+- Repository queues strokes while offline.
+- Snapshot throttle coalesces rapid strokes.
+- Not paired state blocks remote publishing.
+
+### Manual QA
+
+- Pair two users.
+- User A draws; User B sees update in app.
+- Stroke-end updates latest snapshot.
+- iOS lock screen/widget shows latest snapshot.
+- Android notification/widget shows latest snapshot.
+- Offline drawing queues and syncs later.
+- Clear canvas syncs to partner.
+- Unpair stops future updates.
+
+## Open Questions
+
+- Does the backend support WebSocket/SSE, or should MVP use polling?
+- Should snapshot rendering happen on client, server, or both?
+- Should lock screen updates use iOS Live Activity first or WidgetKit first?
+- Should Android MVP prioritize notification or home widget?
+- What is the desired canvas aspect ratio for lock screen display?
+
+## Decision
+
+Proceed with the recommended MVP:
+
+- App-level near-realtime shared drawing.
+- Lock screen snapshot updates through throttled platform-specific surfaces.
+- Pairing/sharedSpaceId is required for sync.
+- First version supports handwriting/drawing strokes; typed text can be added later.

--- a/docs/superpowers/plans/2026-05-08-memorybox-live-canvas-lockscreen-design.md
+++ b/docs/superpowers/plans/2026-05-08-memorybox-live-canvas-lockscreen-design.md
@@ -299,3 +299,13 @@ Proceed with the recommended MVP:
 - Lock screen snapshot updates through throttled platform-specific surfaces.
 - Pairing/sharedSpaceId is required for sync.
 - First version supports handwriting/drawing strokes; typed text can be added later.
+
+## Implemented Repository Scope (2026-05-08)
+
+The MVP implementation follows the OS-limited design:
+
+- iOS adds `CanvasDomain`, `CanvasData`, `CanvasFeature`, local JSON persistence, Moya API boundary, SwiftUI drawing surface, and App Group snapshot writer.
+- Existing iOS WidgetKit extension now tries to show `LiveCanvas/latest_canvas.png` from `group.com.bongbong.coupleapp` before falling back to the D-Day widget content.
+- Android adds serializable canvas models, app-private JSON repository, Compose drawing screen, polling/API path boundary, snapshot renderer/throttle, and a lock-screen-visible notification fallback.
+- Backend realtime/WebSocket is not present in this repository, so the app boundary is stroke-end persistence + fetch-after-sequence polling, with local-first behavior when no base URL exists.
+- Actual iOS Lock Screen refresh cadence remains subject to WidgetKit timeline/system policy; the repository provides the App Group surface and conservative snapshot updates rather than forcing high-frequency lock-screen writes.

--- a/docs/superpowers/plans/2026-05-08-memorybox-pairing-design.md
+++ b/docs/superpowers/plans/2026-05-08-memorybox-pairing-design.md
@@ -192,11 +192,46 @@ States:
 5. Add sharedSpaceId to trip and D-Day persistence/sync.
 6. Add tests and update README/manual QA checklist.
 
+## Implemented App Scope
+
+The first implementation pass adds the shared-space shape without requiring backend schema changes beyond the planned endpoints:
+
+- iOS `FriendDomain` / `FriendData` include `SharedSpaceVO`, `PairingInviteVO`, DTOs, and `/shared-spaces/*` API routing.
+- iOS Friend feature has pairing reducer state and controls for active space fetch, invite creation, accept code, and leave pair.
+- iOS Calendar writes default empty `shared` arrays to the cached `activeSharedSpaceId`.
+- Android adds `SharedSpace`, `SharedSpaceMember`, `PairingInvite`, local/network pairing repositories, and a Compose pairing section inside Friend.
+- Android Calendar, Map trip, and D-Day records can store `sharedSpaceId` and apply the cached active shared space by default.
+- Android D-Day selected widget ID remains device-local; only D-Day record data gets `sharedSpaceId`.
+
+## Verification Notes
+
+Local implementation verification should include:
+
+```bash
+grep -RIn "SharedSpace\|sharedSpaceId\|Pairing" Projects android_memorybox | head -200
+git status --short
+```
+
+When tooling is installed:
+
+```bash
+cd android_memorybox
+./gradlew testDebugUnitTest
+./gradlew assembleDebug
+
+tuist generate
+tuist test
+```
+
+During this implementation session, Java/Tuist/Swift tooling may be unavailable in the runner. In that case, grep/static verification plus code review should be recorded as the executed gate.
+
 ## Open Backend Questions
 
 - Does the existing backend already have pair/group tables, or only friends?
 - Should accepting a friend request automatically create a pair, or should pairing be a separate explicit action?
+- Should calendar sync prefer `sharedSpaceId` as a top-level field, the existing `shared` array, or both during migration?
 - How should shared trip images be uploaded and served?
+- Should D-Day sync expose selected widget item, or keep selection permanently device-local?
 - Should unpair hide old shared data, copy it locally, or keep it visible as historical data?
 
 ## Decision

--- a/docs/superpowers/plans/2026-05-08-memorybox-pairing-design.md
+++ b/docs/superpowers/plans/2026-05-08-memorybox-pairing-design.md
@@ -1,0 +1,204 @@
+# MemoryBox Pairing / SharedSpace Design
+
+## Goal
+
+Add a real pairing feature for couples or close friends so two users can share MemoryBox data such as schedules, diary entries, trip photos, and D-Day widgets.
+
+Start with a simple 1:1 pairing experience, but model it internally as a `sharedSpaceId` so the app can later support group sharing without replacing the data model.
+
+## Current State
+
+The app already has friend request flows on iOS and Android:
+
+- Friend list
+- Friend requests
+- Accept/reject/delete friend
+- Invite/request API paths
+
+The iOS calendar model also has `shared: [String]` fields for todos, schedules, and diaries. That gives us a partial sharing hook, but there is no explicit couple/pair/shared-space model yet.
+
+Current gaps:
+
+- No dedicated pairing state
+- No `sharedSpaceId` or pair identity
+- No automatic sharing for paired users
+- No map trip or D-Day sharing model
+- No clear unpair/re-pair policy
+
+## Recommended Approach
+
+Use a 1:1 pairing UX backed by a future-proof shared space model.
+
+User-facing behavior:
+
+1. User opens Pairing screen.
+2. User can create/share an invite code or enter a partner's code.
+3. When the other user accepts, both users become paired.
+4. The app stores active pairing information locally.
+5. Calendar, trip, and D-Day data are saved/synced under the active `sharedSpaceId` by default.
+6. Either user can unpair, which stops future sharing but does not silently delete local data.
+
+Internal model:
+
+```text
+SharedSpace
+- id: String
+- type: pair
+- name: String?
+- members: [SharedSpaceMember]
+- createdAt: Date
+- updatedAt: Date
+
+SharedSpaceMember
+- userId: String
+- name: String
+- role: owner | member
+- joinedAt: Date
+
+PairingInvite
+- code/token: String
+- sharedSpaceId: String?
+- inviterId: String
+- expiresAt: Date
+- status: pending | accepted | expired | cancelled
+```
+
+Even though `type` starts as `pair`, using `SharedSpace` avoids painting the app into a couple-only corner.
+
+## Data Sharing Rules
+
+### Calendar
+
+Todos, schedules, and diaries should use the existing `shared` fields as a bridge, but the preferred new sync scope is `sharedSpaceId`.
+
+New/updated calendar records should include:
+
+- `sharedSpaceId` when created inside an active pair
+- existing owner/user ID
+- visibility: private/shared, if private entries are needed later
+
+Initial behavior: paired users' calendar records are shared by default.
+
+### Map Trips / Travel Photos
+
+Trip records need a sharing scope added.
+
+Suggested fields:
+
+- `id`
+- `sigunguCode`
+- `title/content/date`
+- `imagePaths` or remote image URLs
+- `ownerId`
+- `sharedSpaceId`
+- `updatedAt`
+
+Local image handling can stay app-private, but shared trips need backend upload/download or a remote media URL contract.
+
+### D-Day Widgets
+
+D-Day records should also support `sharedSpaceId`.
+
+Suggested behavior:
+
+- Shared D-Day list syncs between paired users.
+- Each device can choose its own representative widget item locally.
+- Widget display preference can remain device-local unless explicitly shared later.
+
+## API Shape
+
+Exact backend contract can be adjusted to the existing server, but the app should expect these capabilities:
+
+```text
+POST   /shared-spaces/invites
+POST   /shared-spaces/invites/{code}/accept
+GET    /shared-spaces/active
+DELETE /shared-spaces/{id}/members/me
+
+GET    /calendar?sharedSpaceId={id}
+POST   /calendar/sync
+GET    /trips?sharedSpaceId={id}
+POST   /trips/sync
+GET    /ddays?sharedSpaceId={id}
+POST   /ddays/sync
+```
+
+If the backend already wants to keep `/friend/*`, pairing can be layered on accept-friend by creating or returning a `sharedSpaceId`.
+
+## UX
+
+Add a Pairing/Shared Space screen reachable from Settings or the side menu.
+
+States:
+
+1. Not paired
+   - Show my invite code/link
+   - Enter partner code
+   - Explain what will be shared
+
+2. Pending
+   - Show pending invite/request
+   - Allow cancel
+
+3. Paired
+   - Show partner name
+   - Show shared features: Calendar, Travel, D-Day
+   - Allow unpair with confirmation
+
+4. Error/offline
+   - Show cached pairing state if available
+   - Disable invite/accept actions that require network
+
+## Error Handling
+
+- Missing API base URL: show a non-crashing setup message.
+- Expired/invalid invite: show clear retry message.
+- Already paired: block accepting another pair unless user unpairs first.
+- Network failure: keep local paired state unchanged and retry later.
+- Unpair: require confirmation because it changes sharing behavior.
+
+## Testing Plan
+
+### iOS Unit Tests
+
+- Pairing reducer state transitions
+- Invite creation success/failure
+- Accept invite stores active shared space
+- Unpair clears active shared space
+- Calendar sharedSpaceId is included when active
+
+### Android Unit Tests
+
+- Pairing repository endpoint paths
+- Local pairing state persistence
+- Calendar/trip/D-Day records include sharedSpaceId when paired
+- Unpair stops future shared writes
+
+### Manual QA
+
+- User A creates invite, User B accepts
+- Both apps show paired state
+- Calendar entry created by A appears for B after sync
+- Trip with image created by A appears for B after sync
+- D-Day created by B appears for A after sync
+- Unpair stops new sharing
+
+## Rollout Plan
+
+1. Add shared pairing domain models and local active pairing state.
+2. Add Pairing screen and reducer/view model.
+3. Wire friend accept/invite flow to active shared space.
+4. Add sharedSpaceId to calendar sync.
+5. Add sharedSpaceId to trip and D-Day persistence/sync.
+6. Add tests and update README/manual QA checklist.
+
+## Open Backend Questions
+
+- Does the existing backend already have pair/group tables, or only friends?
+- Should accepting a friend request automatically create a pair, or should pairing be a separate explicit action?
+- How should shared trip images be uploaded and served?
+- Should unpair hide old shared data, copy it locally, or keep it visible as historical data?
+
+## Decision
+
+Proceed with 1:1 pairing UX using `sharedSpaceId` internally. Keep the model extensible for future group sharing.


### PR DESCRIPTION
## Summary
- Added pairing/shared-space support so paired users can share calendar/map/D-Day data.
- Added Live Canvas (`우리 낙서장`) MVP across iOS and Android: shared canvas models, local-first stroke persistence, drawing UI, stroke-end API boundary, snapshot rendering/throttling, and lock-screen/fallback snapshot surfaces.
- Documented Android local build requirements, manual QA, automated coverage, and live canvas verification/OS limitations.

## Test Plan
- [x] Static grep verification for `Live Canvas`, `우리 낙서장`, `CanvasStroke`, and `CanvasSnapshot` references.
- [x] `git diff --check` completed without whitespace errors.
- [x] Checked repository status is clean before push.
- [ ] `android_memorybox/./gradlew testDebugUnitTest` — skipped locally: Java/JAVA_HOME is not configured in this environment.
- [ ] `android_memorybox/./gradlew assembleDebug` — skipped locally: Java/JAVA_HOME is not configured in this environment.
- [ ] `tuist generate` / `tuist test` — skipped locally: Tuist is not installed in this environment.

## Notes
- Backend realtime/WebSocket is not present in this repo, so Live Canvas uses local-first stroke-end persistence plus fetch-after-sequence/API boundary fallback.
- iOS Lock Screen refresh is subject to WidgetKit/system limits; implementation provides App Group snapshot storage and WidgetKit display instead of forced high-frequency lock-screen updates.
- Android uses a lock-screen-visible notification as the first snapshot fallback surface where OS/user notification settings permit.
- Android production Apple/Kakao keys and redirect/console setup remain external configuration.
- Real device/emulator QA is still needed for login, image picker, widget/notification display, and backend flows.
